### PR TITLE
add adapter for spring-aop

### DIFF
--- a/koupleless-adapter-spring-aop/README.md
+++ b/koupleless-adapter-spring-aop/README.md
@@ -1,0 +1,22 @@
+# Springboot AOP Issue Collection
+### Issue Encountered
+Module startup in JdkDynamicAopProxy.getProxy reports an error: xxx referenced from a method is not visible from class loader
+### Issue Cause
+In certain spring-aop versions, there is a bug in the implementation of getProxy. Even if a BizClassLoader is passed in, it will forcibly switch the classLoader to the base ClassLoader because the BizClassLoader does not have a parent.
+```java
+public Object getProxy(@Nullable ClassLoader classLoader) {
+    if (logger.isTraceEnabled()) {
+        logger.trace("Creating JDK dynamic proxy: " + this.advised.getTargetSource());
+    }
+    if (classLoader == null || classLoader.getParent() == null) {
+        classLoader = this.getClass().getClassLoader();
+    }
+    return Proxy.newProxyInstance(classLoader, this.proxiedInterfaces, this);
+}
+```
+In ConfigFileApplicationListener, SpringFactoriesLoader.loadFactories uses the classLoader of the current class to scan for resource files, causing it to only scan the base resource files.
+### Version Range
+springboot 2.7.11, 2.7.12, 3.0.6, 3.0.7, 3.1.0
+spring-aop 5.3.27, 6.0.8, 6.0.9
+### Solution
+Switch to a different version.

--- a/koupleless-adapter-spring-aop/README_zh_CN.md
+++ b/koupleless-adapter-spring-aop/README_zh_CN.md
@@ -1,0 +1,30 @@
+## 适配springboot aop 问题合集issues
+
+### 遇到问题
+模块启动在 JdkDynamicAopProxy.getProxy 报错 xxx referenced from a method is not visible from class loader
+
+### 问题原因
+在特定几个 spring-aop 版本里，getProxy 的实现存在 bug，这里即使传入 BizClassLoader，也会因为 BizClassLoader 没有 parent 而强制切换 classLoader 成了 基座 ClassLoader
+
+```java
+public Object getProxy(@Nullable ClassLoader classLoader) {
+    if (logger.isTraceEnabled()) {
+        logger.trace("Creating JDK dynamic proxy: " + this.advised.getTargetSource());
+    }
+
+    if (classLoader == null || classLoader.getParent() == null) {
+        classLoader = this.getClass().getClassLoader();
+    }
+
+    return Proxy.newProxyInstance(classLoader, this.proxiedInterfaces, this);
+}
+```
+
+ConfigFileApplicationListener中使用SpringFactoriesLoader.loadFactories的地方都是使用当前类的ClassLoader来扫描资源文件，导致只能扫描到基座的资源文件
+
+### 版本范围 
+springboot 2.7.11, 2.7.12, 3.0.6, 3.0.7, 3.1.0
+spring-aop 5.3.27, 6.0.8, 6.0.9
+
+### 解决方法
+更换到其他版本

--- a/koupleless-adapter-spring-aop/pom.xml
+++ b/koupleless-adapter-spring-aop/pom.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alipay.sofa.koupleless</groupId>
+        <artifactId>koupleless-adapter</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>koupleless-adapter-spring-aop</artifactId>
+    <version>${revision}</version>
+
+    <properties>
+        <spring.boot.version>2.3.5.RELEASE</spring.boot.version>
+        <java.version>1.8</java.version>
+        <!-- skip deploy parent bundle -->
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,7 @@
         <module>koupleless-adapter-springboot-2.3</module>
         <module>koupleless-adapter-logback</module>
         <module>koupleless-adapter-rocketmq-4.4</module>
+<!--        <module>koupleless-adapter-spring-aop</module>-->
 
 <!--        jdk17       -->
         <module>koupleless-adapter-log4j2-spring-starter-3.0</module>
@@ -446,8 +447,6 @@
                     </compilerArgs>
                 </configuration>
             </plugin>
-
-
         </plugins>
     </build>
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added comprehensive README files in English and Chinese detailing issues with Spring Boot AOP, including a specific bug related to class loader visibility.
  - Introduced a new Maven POM file for the `koupleless-adapter-spring-aop` module to define project structure and dependencies.

- **Bug Fixes**
  - Documented a solution to mitigate the visibility issue in the `JdkDynamicAopProxy.getProxy` method.

- **Chores**
  - Made minor adjustments to the main `pom.xml` to include the new module in the build configuration (currently commented out).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->