### PR TITLE
add keep for javadoc class

### DIFF
--- a/koupleless-adapter-spring-aop-5.3.27/src/main/java/com/alipay/sofa/koupleless/KeepForJavaDoc.java
+++ b/koupleless-adapter-spring-aop-5.3.27/src/main/java/com/alipay/sofa/koupleless/KeepForJavaDoc.java
@@ -1,0 +1,7 @@
+package com.alipay.sofa.koupleless;
+
+/**
+ *  just for generate javadoc, in case there is no public or protected in this bundle
+ */
+public class KeepForJavaDoc {
+}

--- a/koupleless-adapter-spring-aop-6.0.8/src/main/java/com/alipay/sofa/koupleless/KeepForJavaDoc.java
+++ b/koupleless-adapter-spring-aop-6.0.8/src/main/java/com/alipay/sofa/koupleless/KeepForJavaDoc.java
@@ -1,0 +1,7 @@
+package com.alipay.sofa.koupleless;
+
+/**
+ *  just for generate javadoc, in case there is no public or protected in this bundle
+ */
+public class KeepForJavaDoc {
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a placeholder class to support consistent Javadoc generation, enhancing documentation completeness for the project.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->