### PR TITLE
add web bes and tongweb adapter

### DIFF
--- a/koupleless-adapter-web-bes/README.md
+++ b/koupleless-adapter-web-bes/README.md
@@ -1,0 +1,100 @@
+# koupleless-adapter-bes
+
+组件是作为 [Koupleless](https://github.com/koupleless/koupleless) 项目的一个扩展组件，目的是适配宝蓝德（BES) 容器。
+
+由于 BES 是商业软件，在该仓库中无法直接引入，所以需要本地已经有 BES 依赖包。
+
+项目目前仅在 BES 9.5.5.004 版本中验证过，其他版本需要自行验证，必要的话需要根据相同的思路进行调整。
+
+如果不需要使用同一端口来安装BIZ模块,只需要关注下文安装依赖章节提到的注意事项即可，不需要引入本项目相关的依赖。
+
+## 快速开始
+### 1. 安装依赖
+首先需要确保已经在maven仓库中导入了BES相关的依赖，参考导入脚本如下：
+```shell
+mvn install:install-file -Dfile=D:/software/xc/BES-EMBED/bes-lite-spring-boot-starter-9.5.5.004.jar -DgroupId=com.bes.besstarter -DartifactId=bes-lite-spring-boot-starter -Dversion=9.5.5.004 -Dpackaging=jar
+
+mvn install:install-file -Dfile=D:/software/xc/BES-EMBED/bes-gmssl-9.5.5.004.jar -DgroupId=com.bes.besstarter -DartifactId=bes-gmssl -Dversion=9.5.5.004 -Dpackaging=jar
+
+mvn install:install-file -Dfile=D:/software/xc/BES-EMBED/bes-jdbcra-9.5.5.004.jar -DgroupId=com.bes.besstarter -DartifactId=bes-jdbcra -Dversion=9.5.5.004 -Dpackaging=jar
+
+mvn install:install-file -Dfile=D:/software/xc/BES-EMBED/bes-websocket-9.5.5.004.jar -DgroupId=com.bes.besstarter -DartifactId=bes-websocket -Dversion=9.5.5.004 -Dpackaging=jar
+```
+### 2. 编译安装本项目插件
+进入本项目的 bes9-web-adapter 目录执行 `mvn install` 命令即可。
+项目将会安装 bes-web-ark-plugin 和 bes-sofa-ark-springboot-starter 两个模块。
+
+### 3. 基座中引入本项目组件
+首先需要根据koupleless的文档，[将项目升级为Koupleless基座](https://koupleless.io/docs/tutorials/base-create/springboot-and-sofaboot/)
+
+然后将依赖中提到的
+```xml
+<dependency>
+    <groupId>com.alipay.sofa</groupId>
+    <artifactId>web-ark-plugin</artifactId>
+    <version>${sofa.ark.version}</version>
+</dependency>
+```
+替换为本项目的坐标
+```xml
+<dependency>
+    <groupId>com.alipay.sofa</groupId>
+    <artifactId>bes-web-ark-plugin</artifactId>
+    <version>${sofa.ark.version}</version>
+</dependency>
+<dependency>
+   <groupId>com.alipay.sofa</groupId>
+   <artifactId>bes-sofa-ark-springboot-starter</artifactId>
+   <version>${sofa.ark.version}</version>
+</dependency>
+```
+
+引入BES相关依赖（同时需要exclude tomcat的依赖）。参考依赖如下：
+```xml
+       <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.bes.besstarter</groupId>
+            <artifactId>bes-lite-spring-boot-starter</artifactId>
+            <version>9.5.5.004</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.bes.besstarter</groupId>
+            <artifactId>bes-gmssl</artifactId>
+            <version>9.5.5.004</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.bes.besstarter</groupId>
+            <artifactId>bes-jdbcra</artifactId>
+            <version>9.5.5.004</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.bes.besstarter</groupId>
+            <artifactId>bes-websocket</artifactId>
+            <version>9.5.5.004</version>
+        </dependency>
+```
+
+### 4. 基座中增加宝蓝德特殊配置
+为什么需要这个配置， 是因为 koupleless其中 SOFAArk组件对于依赖包的识别机制与BES的包结构冲突，[参考这里](https://github.com/sofastack/sofa-ark/pull/997)
+
+需要在基座根目录 ark 配置文件中（`conf/ark/bootstrap.properties` 或 `conf/ark/bootstrap.yml`）增加白名单
+
+```properties
+declared.libraries.whitelist=com.bes.besstarter:bes-sofa-ark-springboot-starter
+```
+
+### 5. 完成
+完成上述步骤后，即可在 Koupleless 基座和模块中使用 BES 启动项目。

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/pom.xml
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/pom.xml
@@ -1,0 +1,138 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.alipay.sofa</groupId>
+    <artifactId>bes-sofa-ark-springboot-starter</artifactId>
+    <version>2.2.14</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring.boot.version>2.7.14</spring.boot.version>
+        <sofa.ark.version>2.2.14</sofa.ark.version>
+        <junit.version>4.13.1</junit.version>
+        <reactor-netty.version>0.9.19.RELEASE</reactor-netty.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-support-starter</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-api</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-compatible-springboot1</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-compatible-springboot2</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>logback-classic</artifactId>
+                    <groupId>ch.qos.logback</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!--junit-->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.17.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-loader</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty</artifactId>
+            <version>${reactor-netty.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- bes -->
+        <dependency>
+            <groupId>com.bes.besstarter</groupId>
+            <artifactId>bes-lite-spring-boot-starter</artifactId>
+            <version>9.5.5.004</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <threadCount>1</threadCount>
+                    <properties>
+                        <junit>false</junit>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/ArkBesServletLegacyAutoConfiguration.java
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/ArkBesServletLegacyAutoConfiguration.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.springboot;
+
+import com.alipay.sofa.ark.springboot.condition.ConditionalOnArkEnabled;
+import com.alipay.sofa.ark.springboot.web.ArkBesServletWebServerFactory;
+import com.bes.enterprise.springboot.autoconfigure.BesServletWebServerFactoryConfiguration;
+import com.bes.enterprise.springboot.embedded.BesServletWebServerFactory;
+import com.bes.enterprise.web.Embedded;
+import com.bes.enterprise.web.crane.UpgradeProtocol;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.SearchStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.Servlet;
+
+/**
+ * adapt to springboot 2.1.9.RELEASE
+ * @author gaosaroma
+ * @since 2.2.8
+ */
+@Configuration
+@ConditionalOnClass(BesServletWebServerFactoryConfiguration.class)
+@ConditionalOnArkEnabled
+@AutoConfigureBefore(BesServletWebServerFactoryConfiguration.class)
+public class ArkBesServletLegacyAutoConfiguration {
+
+    @Configuration
+    @ConditionalOnClass(value = { Servlet.class, Embedded.class, UpgradeProtocol.class,
+            BesServletWebServerFactory.class }, name = { "com.alipay.sofa.ark.web.embed.bes.ArkBesEmbeddedWebappClassLoader" })
+    @ConditionalOnMissingBean(value = BesServletWebServerFactory.class, search = SearchStrategy.CURRENT)
+    public static class EmbeddedArkBes {
+
+        @Bean
+        @ConditionalOnMissingBean(ArkBesServletWebServerFactory.class)
+        public BesServletWebServerFactory besServletWebServerFactory() {
+            return new ArkBesServletWebServerFactory();
+        }
+    }
+}

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/web/ArkBesServletWebServerFactory.java
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/web/ArkBesServletWebServerFactory.java
@@ -1,0 +1,376 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.springboot.web;
+
+import com.alipay.sofa.ark.common.util.AssertUtils;
+import com.alipay.sofa.ark.spi.model.Biz;
+import com.alipay.sofa.ark.spi.service.ArkInject;
+import com.alipay.sofa.ark.spi.service.biz.BizManagerService;
+import com.alipay.sofa.ark.spi.web.EmbeddedServerService;
+import com.bes.enterprise.springboot.embedded.BesServletWebServerFactory;
+import com.bes.enterprise.web.BESConnector;
+import com.bes.enterprise.web.Embedded;
+import com.bes.enterprise.web.util.scan.StandardJarScanFilter;
+import com.bes.enterprise.webtier.*;
+import com.bes.enterprise.webtier.connector.Connector;
+import com.bes.enterprise.webtier.core.DefaultContext;
+import com.bes.enterprise.webtier.loader.WebappLoader;
+import com.bes.enterprise.webtier.webresources.StandardRoot;
+import org.springframework.boot.system.ApplicationHome;
+import org.springframework.boot.system.ApplicationPid;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.ServletContainerInitializer;
+import java.io.File;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import static com.alipay.sofa.ark.spi.constant.Constants.ROOT_WEB_CONTEXT_PATH;
+
+/**
+ * @author Phillip Webb
+ * @author Dave Syer
+ * @author Brock Mills
+ * @author Stephane Nicoll
+ * @author Andy Wilkinson
+ * @author Eddú Meléndez
+ * @author Christoffer Sawicki
+ * @author qilong.zql
+ * @since 0.6.0
+ */
+public class ArkBesServletWebServerFactory extends BesServletWebServerFactory {
+
+    private static final Charset            DEFAULT_CHARSET = StandardCharsets.UTF_8;
+
+    @ArkInject
+    private EmbeddedServerService<Embedded> embeddedServerService;
+
+    @ArkInject
+    private BizManagerService               bizManagerService;
+
+    private File                            baseDirectory;
+
+    private String                          protocol        = DEFAULT_PROTOCOL;
+
+    private int                             backgroundProcessorDelay;
+
+    private final ApplicationPid pid;
+
+    public ArkBesServletWebServerFactory() {
+        super();
+        this.pid = new ApplicationPid();
+    }
+
+    @Override
+    public WebServer getWebServer(ServletContextInitializer... initializers) {
+        if (embeddedServerService == null && ArkClient.getInjectionService() != null) {
+            // 非应用上下文 (例如: Spring Management Context) 没有经历 Start 生命周期, 不会被注入 ArkServiceInjectProcessor,
+            // 因此 @ArkInject 没有被处理, 需要手动处理
+            ArkClient.getInjectionService().inject(this);
+        }
+        if (embeddedServerService == null) {
+            return super.getWebServer(initializers);
+        } else if (embeddedServerService.getEmbedServer(getPort()) == null) {
+            embeddedServerService.putEmbedServer(getPort(), initEmbedServer());
+        }
+        Embedded embedded = (Embedded) embeddedServerService.getEmbedServer(getPort());
+        prepareContext(embedded.getHost(), initializers);
+        return getWebServer(embedded);
+    }
+
+    @Override
+    public String getContextPath() {
+        String contextPath = super.getContextPath();
+        if (bizManagerService == null) {
+            return contextPath;
+        }
+        Biz biz = bizManagerService.getBizByClassLoader(Thread.currentThread()
+                .getContextClassLoader());
+        if (!StringUtils.isEmpty(contextPath)) {
+            return contextPath;
+        } else if (biz != null) {
+            if (StringUtils.isEmpty(biz.getWebContextPath())) {
+                return ROOT_WEB_CONTEXT_PATH;
+            }
+            return biz.getWebContextPath();
+        } else {
+            return ROOT_WEB_CONTEXT_PATH;
+        }
+    }
+
+    private Embedded initEmbedServer() {
+        Embedded embedded = new Embedded();
+        File baseDir = this.initBaseDir();
+        embedded.setBaseDir(baseDir.getAbsolutePath());
+        customizeConnector(embedded);
+        this.configureEngine(embedded.getEngine());
+        embedded.getHost().setAutoDeploy(false);
+        for (Connector additionalConnector : getAdditionalBesConnectors()) {
+            embedded.getService().addConnector(additionalConnector);
+        }
+        this.customizeVirtualServer(embedded.getHost());
+        return embedded;
+    }
+
+    private File initBaseDir() {
+        File baseDir = null;
+        String installRoot = System.getProperty("com.bes.installRoot");
+        if (installRoot != null) {
+            baseDir = new File(installRoot);
+        }
+
+        if (baseDir == null && this.baseDirectory != null) {
+            baseDir = this.baseDirectory;
+        }
+
+        if (baseDir == null) {
+            baseDir = this.getDefaultBaseDirectory();
+            File licenseDir = new File(baseDir, "license");
+            if (!licenseDir.exists() && !licenseDir.mkdir()) {
+                throw new IllegalStateException(String.format(
+                        "Failed to create license directory %s.", licenseDir.getAbsolutePath()));
+            }
+        }
+
+        System.setProperty("com.bes.installRoot", baseDir.getAbsolutePath());
+        System.setProperty("com.bes.instanceRoot", baseDir.getAbsolutePath());
+        return baseDir;
+    }
+
+    private File getDefaultBaseDirectory() {
+        String userDir = System.getProperty("user.dir");
+        String fileName = "bes." + this.getPort() + "." + this.pid;
+        File baseDir;
+        if (StringUtils.hasLength(userDir)) {
+            baseDir = new File(userDir + File.separator + "appserver", fileName);
+        } else {
+            ApplicationHome applicationHome = new ApplicationHome(this.getClass());
+            baseDir = new File(applicationHome.getDir() + File.separator + "appserver", fileName);
+        }
+
+        if (!baseDir.exists() && !baseDir.mkdirs()) {
+            throw new IllegalStateException(String.format("Failed to create base directory %s.",
+                    baseDir.getAbsolutePath()));
+        } else {
+            return baseDir;
+        }
+    }
+
+    @Override
+    public void setBaseDirectory(File baseDirectory) {
+        this.baseDirectory = baseDirectory;
+    }
+
+    /**
+     * The Tomcat protocol to use when create the {@link Connector}.
+     * @param protocol the protocol
+     * @see Connector#Connector(String)
+     */
+    @Override
+    public void setProtocol(String protocol) {
+        AssertUtils.isFalse(StringUtils.isEmpty(protocol), "Protocol must not be empty");
+        this.protocol = protocol;
+    }
+
+    @Override
+    public void setBackgroundProcessorDelay(int delay) {
+        this.backgroundProcessorDelay = delay;
+    }
+
+    private void configureEngine(Engine engine) {
+        engine.setBackgroundProcessorDelay(this.backgroundProcessorDelay);
+        for (Valve valve : getEngineValves()) {
+            engine.getPipeline().addValve(valve);
+        }
+    }
+
+    @Override
+    protected void postProcessContext(Context context) {
+        ((WebappLoader) context.getLoader())
+                .setLoaderClass("com.alipay.sofa.ark.web.embed.bes.ArkBesEmbeddedWebappClassLoader");
+    }
+
+    @Override
+    protected void prepareContext(Host host, ServletContextInitializer[] initializers) {
+        if (host.getState() == LifecycleState.NEW) {
+            super.prepareContext(host, initializers);
+        } else {
+            File documentRoot = getValidDocumentRoot();
+            DefaultContext context = new DefaultContext();
+            if (documentRoot != null) {
+                context.setResources(new StandardRoot(context));
+            }
+            context.setName(getContextPath());
+            context.setDisplayName(getDisplayName());
+            context.setPath(getContextPath());
+            File docBase = (documentRoot != null) ? documentRoot : createTempDir("bes-docbase");
+            context.setDocBase(docBase.getAbsolutePath());
+            context.addLifecycleListener(new Embedded.FixContextListener());
+            context.setParentClassLoader(Thread.currentThread().getContextClassLoader());
+            resetDefaultLocaleMapping(context);
+            addLocaleMappings(context);
+            context.setUseRelativeRedirects(false);
+            configureTldSkipPatterns(context);
+            WebappLoader loader = new WebappLoader();
+            loader
+                    .setLoaderClass("com.alipay.sofa.ark.web.embed.bes.ArkBesEmbeddedWebappClassLoader");
+            loader.setDelegate(true);
+            context.setLoader(loader);
+            if (isRegisterDefaultServlet()) {
+                addDefaultServlet(context);
+            }
+            if (shouldRegisterJspServlet()) {
+                addJspServlet(context);
+                addJasperInitializer(context);
+            }
+            context.addLifecycleListener(new StaticResourceConfigurer(context));
+            ServletContextInitializer[] initializersToUse = mergeInitializers(initializers);
+            context.setParent(host);
+            configureContext(context, initializersToUse);
+            host.addChild(context);
+        }
+    }
+
+    /**
+     * Override Tomcat's default locale mappings to align with other servers. See
+     * {@code org.apache.catalina.util.CharsetMapperDefault.properties}.
+     * @param context the context to reset
+     */
+    private void resetDefaultLocaleMapping(DefaultContext context) {
+        context.addLocaleEncodingMappingParameter(Locale.ENGLISH.toString(),
+                DEFAULT_CHARSET.displayName());
+        context.addLocaleEncodingMappingParameter(Locale.FRENCH.toString(),
+                DEFAULT_CHARSET.displayName());
+    }
+
+    private void addLocaleMappings(DefaultContext context) {
+        for (Map.Entry<Locale, Charset> entry : getLocaleCharsetMappings().entrySet()) {
+            context.addLocaleEncodingMappingParameter(entry.getKey().toString(), entry.getValue()
+                    .toString());
+        }
+    }
+
+    private void configureTldSkipPatterns(DefaultContext context) {
+        StandardJarScanFilter filter = new StandardJarScanFilter();
+        filter.setTldSkip(StringUtils.collectionToCommaDelimitedString(getTldSkipPatterns()));
+        context.getJarScanner().setJarScanFilter(filter);
+    }
+
+    private void addDefaultServlet(Context context) {
+        Wrapper defaultServlet = context.createWrapper();
+        defaultServlet.setName("default");
+        defaultServlet.setServletClass("org.apache.catalina.servlets.DefaultServlet");
+        defaultServlet.addInitParameter("debug", "0");
+        defaultServlet.addInitParameter("listings", "false");
+        defaultServlet.setLoadOnStartup(1);
+        // Otherwise the default location of a Spring DispatcherServlet cannot be set
+        defaultServlet.setOverridable(true);
+        context.addChild(defaultServlet);
+        context.addServletMappingDecoded("/", "default");
+    }
+
+    private void addJspServlet(Context context) {
+        Wrapper jspServlet = context.createWrapper();
+        jspServlet.setName("jsp");
+        jspServlet.setServletClass(getJsp().getClassName());
+        jspServlet.addInitParameter("fork", "false");
+        for (Map.Entry<String, String> entry : getJsp().getInitParameters().entrySet()) {
+            jspServlet.addInitParameter(entry.getKey(), entry.getValue());
+        }
+        jspServlet.setLoadOnStartup(3);
+        context.addChild(jspServlet);
+        context.addServletMappingDecoded("*.jsp", "jsp");
+        context.addServletMappingDecoded("*.jspx", "jsp");
+    }
+
+    private void addJasperInitializer(DefaultContext context) {
+        try {
+            ServletContainerInitializer initializer = (ServletContainerInitializer) ClassUtils
+                    .forName("org.apache.jasper.servlet.JasperInitializer", null).newInstance();
+            context.addServletContainerInitializer(initializer, null);
+        } catch (Exception ex) {
+            // Probably not Tomcat 8
+        }
+    }
+
+    final class StaticResourceConfigurer implements LifecycleListener {
+
+        private final Context context;
+
+        private StaticResourceConfigurer(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public void lifecycleEvent(LifecycleEvent event) {
+            if (event.getType().equals(Lifecycle.CONFIGURE_START_EVENT)) {
+                addResourceJars(getUrlsOfJarsWithMetaInfResources());
+            }
+        }
+
+        private void addResourceJars(List<URL> resourceJarUrls) {
+            for (URL url : resourceJarUrls) {
+                String path = url.getPath();
+                if (path.endsWith(".jar") || path.endsWith(".jar!/")) {
+                    String jar = url.toString();
+                    if (!jar.startsWith("jar:")) {
+                        // A jar file in the file system. Convert to Jar URL.
+                        jar = "jar:" + jar + "!/";
+                    }
+                    addResourceSet(jar);
+                } else {
+                    addResourceSet(url.toString());
+                }
+            }
+        }
+
+        private void addResourceSet(String resource) {
+            try {
+                if (isInsideNestedJar(resource)) {
+                    // It's a nested jar but we now don't want the suffix because Tomcat
+                    // is going to try and locate it as a root URL (not the resource
+                    // inside it)
+                    resource = resource.substring(0, resource.length() - 2);
+                }
+                URL url = new URL(resource);
+                String path = "/META-INF/resources";
+                this.context.getResources().createWebResourceSet(
+                        WebResourceRoot.ResourceSetType.RESOURCE_JAR, "/", url, path);
+            } catch (Exception ex) {
+                // Ignore (probably not a directory)
+            }
+        }
+
+        private boolean isInsideNestedJar(String dir) {
+            return dir.indexOf("!/") < dir.lastIndexOf("!/");
+        }
+    }
+
+    /**
+     * additional processing to the Tomcat server.
+     */
+    protected WebServer getWebServer(Embedded embedded) {
+        return new ArkBesWebServer(embedded, getPort() >= 0, embedded);
+    }
+}

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/web/ArkBesWebServer.java
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/web/ArkBesWebServer.java
@@ -1,0 +1,329 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.springboot.web;
+
+import com.bes.enterprise.naming.ContextBindings;
+import com.bes.enterprise.springboot.embedded.ConnectorStartFailedException;
+import com.bes.enterprise.web.Embedded;
+import com.bes.enterprise.webtier.*;
+import com.bes.enterprise.webtier.connector.Connector;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.boot.web.server.WebServerException;
+import org.springframework.util.Assert;
+
+import javax.naming.NamingException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+
+/**
+ * NOTE: Tomcat instance will start immediately when create ArkTomcatWebServer object.
+ *
+ * @author Brian Clozel
+ * @author Kristine Jetzke
+ * @author 0.6.0
+ * @since 2.0.0
+ */
+public class ArkBesWebServer implements WebServer {
+
+    private static final Log                logger            = LogFactory
+            .getLog(ArkBesWebServer.class);
+
+    private static final AtomicInteger      containerCounter  = new AtomicInteger(-1);
+
+    private final Object                    monitor           = new Object();
+
+    private final Map<Service, Connector[]> serviceConnectors = new HashMap<>();
+
+    private final Embedded                  embedded;
+
+    private final boolean                   autoStart;
+
+    private volatile boolean                started;
+
+    private Thread                          awaitThread;
+
+    private Embedded                        arkEmbeded;
+
+    /**
+     * Create a new {@link ArkBesWebServer} instance.
+     * @param embedded the underlying BesWebServer
+     */
+    public ArkBesWebServer(Embedded embedded) {
+        this(embedded, true);
+    }
+
+    /**
+     * Create a new {@link ArkBesWebServer} instance.
+     * @param embedded the underlying BesWebServer
+     * @param autoStart if the server should be started
+     */
+    public ArkBesWebServer(Embedded embedded, boolean autoStart) {
+        Assert.notNull(embedded, "Bes Server must not be null");
+        this.embedded = embedded;
+        this.autoStart = autoStart;
+        initialize();
+    }
+
+    public ArkBesWebServer(Embedded embedded, boolean autoStart, Embedded arkEmbeded) {
+        this(embedded, autoStart);
+        this.arkEmbeded = arkEmbeded;
+    }
+
+    private void initialize() throws WebServerException {
+        logger.info("BesWebServer initialized with port(s): " + getPortsDescription(false));
+        synchronized (this.monitor) {
+            try {
+                addInstanceIdToEngineName();
+
+                Context context = findContext();
+                context.addLifecycleListener((event) -> {
+                    if (context.equals(event.getSource())
+                            && Lifecycle.START_EVENT.equals(event.getType())) {
+                        // Remove service connectors so that protocol binding doesn't
+                        // happen when the service is started.
+                        removeServiceConnectors();
+                    }
+                });
+
+                // Start the server to trigger initialization listeners
+                this.embedded.start();
+
+                // We can re-throw failure exception directly in the main thread
+                rethrowDeferredStartupExceptions();
+
+                try {
+                    ContextBindings.bindClassLoader(context, context.getNamingToken(),
+                            Thread.currentThread().getContextClassLoader());
+                }
+                catch (NamingException ex) {
+                    // Naming is not enabled. Continue
+                }
+
+                // Unlike Jetty, all BesWebServer threads are daemon threads. We create a
+                // blocking non-daemon to stop immediate shutdown
+                startDaemonAwaitThread();
+            }
+            catch (Exception ex) {
+                stopSilently();
+                throw new WebServerException("Unable to start embedded BesWebServer", ex);
+            }
+        }
+    }
+
+    private Context findContext() {
+        for (Container child : this.embedded.getHost().findChildren()) {
+            if (child instanceof Context) {
+                if (child.getParentClassLoader().equals(
+                        Thread.currentThread().getContextClassLoader())) {
+                    return (Context) child;
+                }
+            }
+        }
+        throw new IllegalStateException("The host does not contain a Context");
+    }
+
+    private void addInstanceIdToEngineName() {
+        int instanceId = containerCounter.incrementAndGet();
+        if (instanceId > 0) { // We already have a BesWebServer container, so just return the existing BesWebServer.
+            Engine engine = this.embedded.getEngine();
+            engine.setName(engine.getName() + "-" + instanceId);
+        }
+    }
+
+    private void removeServiceConnectors() {
+        for (Service service : this.embedded.getServer().findServices()) {
+            Connector[] connectors = service.findConnectors().clone();
+            this.serviceConnectors.put(service, connectors);
+            for (Connector connector : connectors) {
+                service.removeConnector(connector);
+            }
+        }
+    }
+
+    private void rethrowDeferredStartupExceptions() throws Exception {
+        Container[] children = this.embedded.getHost().findChildren();
+        for (Container container : children) {
+            // just to check current biz status
+            if (container.getParentClassLoader() == Thread.currentThread().getContextClassLoader()) {
+                if (!LifecycleState.STARTED.equals(container.getState())) {
+                    throw new IllegalStateException(container + " failed to start");
+                }
+            }
+        }
+    }
+
+    private void startDaemonAwaitThread() {
+        awaitThread = new Thread("container-" + (containerCounter.get())) {
+
+            @Override
+            public void run() {
+                getBesCore().getServer().await();
+            }
+
+        };
+        awaitThread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
+        awaitThread.setDaemon(false);
+        awaitThread.start();
+    }
+
+    @Override
+    public void start() throws WebServerException {
+        synchronized (this.monitor) {
+            if (this.started) {
+                return;
+            }
+            try {
+                addPreviouslyRemovedConnectors();
+                this.embedded.getConnector();
+                checkThatConnectorsHaveStarted();
+                this.started = true;
+                logger.info("BesWebServer started on port(s): " + getPortsDescription(true)
+                        + " with context path '" + getContextPath() + "'");
+            } catch (ConnectorStartFailedException ex) {
+                stopSilently();
+                throw ex;
+            } catch (Exception ex) {
+                throw new WebServerException("Unable to start embedded BesWebServer", ex);
+            } finally {
+                Context context = findContext();
+                ContextBindings.unbindClassLoader(context, context.getNamingToken(), getClass()
+                        .getClassLoader());
+            }
+        }
+    }
+
+    void checkThatConnectorsHaveStarted() {
+        checkConnectorHasStarted(this.embedded.getConnector());
+        for (Connector connector : this.embedded.getService().findConnectors()) {
+            checkConnectorHasStarted(connector);
+        }
+    }
+
+    private void checkConnectorHasStarted(Connector connector) {
+        if (LifecycleState.FAILED.equals(connector.getState())) {
+            throw new ConnectorStartFailedException(connector.getPort());
+        }
+    }
+
+    public void stopSilently() {
+        stopContext();
+        try {
+            stopEmbededServerIfNecessary();
+        } catch (LifecycleException ex) {
+            // Ignore
+        }
+    }
+
+    private void stopContext() {
+        Context context = findContext();
+        getBesCore().getHost().removeChild(context);
+    }
+
+    private void stopEmbededServerIfNecessary() throws LifecycleException {
+        if (embedded != arkEmbeded) {
+            embedded.destroy();
+        }
+        awaitThread.stop();
+    }
+
+    void addPreviouslyRemovedConnectors() {
+        Service[] services = this.embedded.getServer().findServices();
+        for (Service service : services) {
+            Connector[] connectors = this.serviceConnectors.get(service);
+            if (connectors != null) {
+                for (Connector connector : connectors) {
+                    service.addConnector(connector);
+                    if (!this.autoStart) {
+                        stopProtocolHandler(connector);
+                    }
+                }
+                this.serviceConnectors.remove(service);
+            }
+        }
+    }
+
+    private void stopProtocolHandler(Connector connector) {
+        try {
+            connector.getProtocolHandler().stop();
+        } catch (Exception ex) {
+            logger.error("Cannot pause connector: ", ex);
+        }
+    }
+
+    Map<Service, Connector[]> getServiceConnectors() {
+        return this.serviceConnectors;
+    }
+
+    @Override
+    public void stop() throws WebServerException {
+        synchronized (this.monitor) {
+            boolean wasStarted = this.started;
+            try {
+                this.started = false;
+                try {
+                    stopContext();
+                    stopEmbededServerIfNecessary();
+                } catch (Throwable ex) {
+                    // swallow and continue
+                }
+            } catch (Exception ex) {
+                throw new WebServerException("Unable to stop embedded BesWebServer", ex);
+            } finally {
+                if (wasStarted) {
+                    containerCounter.decrementAndGet();
+                }
+            }
+        }
+    }
+
+    private String getPortsDescription(boolean localPort) {
+        StringBuilder ports = new StringBuilder();
+        for (Connector connector : this.embedded.getService().findConnectors()) {
+            if (ports.length() != 0) {
+                ports.append(' ');
+            }
+            int port = localPort ? connector.getLocalPort() : connector.getPort();
+            ports.append(port).append(" (").append(connector.getScheme()).append(')');
+        }
+        return ports.toString();
+    }
+
+    @Override
+    public int getPort() {
+        Connector connector = this.embedded.getConnector();
+        if (connector != null) {
+            return connector.getLocalPort();
+        }
+        return 0;
+    }
+
+    private String getContextPath() {
+        return findContext().getPath();
+    }
+
+    /**
+     * Returns access to the underlying BesWebServer.
+     * @return the BesWebServer
+     */
+    public Embedded getBesCore() {
+        return this.embedded;
+    }
+}

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/src/main/resources/META-INF/spring.factories
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-sofa-ark-springboot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.alipay.sofa.ark.springboot.ArkBesServletLegacyAutoConfiguration

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/pom.xml
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.alipay.sofa</groupId>
+    <artifactId>bes-web-ark-plugin</artifactId>
+    <version>2.2.14</version>
+
+    <properties>
+        <sofa.ark.version>2.2.14</sofa.ark.version>
+        <mockito.version>3.6.0</mockito.version>
+        <junit.version>4.13.1</junit.version>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.bes.besstarter</groupId>
+            <artifactId>bes-lite-spring-boot-starter</artifactId>
+            <version>9.5.5.004</version>
+            <scope>provided</scope>
+        </dependency>
+
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-common</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.alipay.sofa</groupId>
+                <artifactId>sofa-ark-plugin-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <goals>
+                            <goal>ark-plugin</goal>
+                        </goals>
+
+                        <configuration>
+                            <activator>com.alipay.sofa.ark.web.embed.BesWebPluginActivator</activator>
+                            <excludes>
+                                <exclude>*:*:*</exclude>
+                                <exclude>com.alipay.sofa:bes-web-ark-plugin</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/BesWebPluginActivator.java
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/BesWebPluginActivator.java
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.web.embed;
+
+import com.alipay.sofa.ark.common.log.ArkLoggerFactory;
+import com.alipay.sofa.ark.spi.model.PluginContext;
+import com.alipay.sofa.ark.spi.service.PluginActivator;
+import com.alipay.sofa.ark.spi.web.EmbeddedServerService;
+import com.alipay.sofa.ark.web.embed.bes.EmbeddedServerServiceImpl;
+import com.bes.enterprise.web.Embedded;
+
+public class BesWebPluginActivator implements PluginActivator {
+    EmbeddedServerService embeddedServerService = new EmbeddedServerServiceImpl();
+
+    public BesWebPluginActivator() {
+    }
+
+    public void start(PluginContext context) {
+        context.publishService(EmbeddedServerService.class, this.embeddedServerService);
+    }
+
+    public void stop(PluginContext context) {
+    }
+}

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/bes/ArkBesEmbeddedWebappClassLoader.java
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/bes/ArkBesEmbeddedWebappClassLoader.java
@@ -1,0 +1,127 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.web.embed.bes;
+
+import com.alipay.sofa.ark.common.log.ArkLoggerFactory;
+import com.bes.enterprise.webtier.loader.ParallelWebappClassLoader;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+
+public class ArkBesEmbeddedWebappClassLoader extends ParallelWebappClassLoader {
+    private static final Logger LOGGER = ArkLoggerFactory
+                                           .getLogger(ArkBesEmbeddedWebappClassLoader.class);
+
+    public ArkBesEmbeddedWebappClassLoader() {
+    }
+
+    public ArkBesEmbeddedWebappClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
+    public URL findResource(String name) {
+        return null;
+    }
+
+    public Enumeration<URL> findResources(String name) throws IOException {
+        return Collections.emptyEnumeration();
+    }
+
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (this.getClassLoadingLock(name)) {
+            Class<?> result = this.findExistingLoadedClass(name);
+            result = result != null ? result : this.doLoadClass(name);
+            if (result == null) {
+                throw new ClassNotFoundException(name);
+            } else {
+                return this.resolveIfNecessary(result, resolve);
+            }
+        }
+    }
+
+    private Class<?> findExistingLoadedClass(String name) {
+        Class<?> resultClass = this.findLoadedClass0(name);
+        resultClass = resultClass != null ? resultClass : this.findLoadedClass(name);
+        return resultClass;
+    }
+
+    private Class<?> doLoadClass(String name) throws ClassNotFoundException {
+        this.checkPackageAccess(name);
+        Class result;
+        if (!this.delegate && !this.filter(name, true)) {
+            result = this.findClassIgnoringNotFound(name);
+            return result != null ? result : this.loadFromParent(name);
+        } else {
+            result = this.loadFromParent(name);
+            return result != null ? result : this.findClassIgnoringNotFound(name);
+        }
+    }
+
+    private Class<?> resolveIfNecessary(Class<?> resultClass, boolean resolve) {
+        if (resolve) {
+            this.resolveClass(resultClass);
+        }
+
+        return resultClass;
+    }
+
+    protected void addURL(URL url) {
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Ignoring request to add " + url + " to the bes classloader");
+        }
+
+    }
+
+    private Class<?> loadFromParent(String name) {
+        if (this.parent == null) {
+            return null;
+        } else {
+            try {
+                return Class.forName(name, false, this.parent);
+            } catch (ClassNotFoundException var3) {
+                return null;
+            }
+        }
+    }
+
+    private Class<?> findClassIgnoringNotFound(String name) {
+        try {
+            return this.findClass(name);
+        } catch (ClassNotFoundException var3) {
+            return null;
+        }
+    }
+
+    void checkPackageAccess(String name) throws ClassNotFoundException {
+        if (this.securityManager != null && name.lastIndexOf(46) >= 0) {
+            try {
+                this.securityManager.checkPackageAccess(name.substring(0, name.lastIndexOf(46)));
+            } catch (SecurityException var3) {
+                throw new ClassNotFoundException(
+                    "Security Violation, attempt to use Restricted Class: " + name, var3);
+            }
+        }
+
+    }
+
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+}

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/bes/EmbeddedServerServiceImpl.java
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/bes/EmbeddedServerServiceImpl.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.web.embed.bes;
+
+import com.alipay.sofa.ark.spi.web.AbstractEmbeddedServerService;
+import com.bes.enterprise.web.Embedded;
+
+public class EmbeddedServerServiceImpl extends AbstractEmbeddedServerService<Embedded> {
+}

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/test/java/com/alipay/sofa/ark/web/embed/WebPluginActivatorTest.java
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/test/java/com/alipay/sofa/ark/web/embed/WebPluginActivatorTest.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.web.embed;
+
+import com.alipay.sofa.ark.spi.model.PluginContext;
+import com.alipay.sofa.ark.spi.web.EmbeddedServerService;
+import com.bes.enterprise.web.Embedded;
+import com.bes.enterprise.webtier.LifecycleException;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.mockito.Mockito.*;
+
+public class WebPluginActivatorTest {
+
+    private BesWebPluginActivator    webPluginActivator            = new BesWebPluginActivator();
+
+    private EmbeddedServerService originalEmbeddedServerService = webPluginActivator.embeddedServerService;
+
+    @Before
+    public void setUp() {
+    }
+
+    @After
+    public void tearDown() {
+        webPluginActivator.embeddedServerService = originalEmbeddedServerService;
+    }
+
+    @Test
+    public void testStartAndStop() throws LifecycleException {
+
+        EmbeddedServerService embeddedServerService = mock(EmbeddedServerService.class);
+        webPluginActivator.embeddedServerService = embeddedServerService;
+
+        PluginContext pluginContext = mock(PluginContext.class);
+        webPluginActivator.start(pluginContext);
+        verify(pluginContext, times(1)).publishService(EmbeddedServerService.class,
+            embeddedServerService);
+
+        Embedded embedded = mock(Embedded.class);
+        when(embeddedServerService.getEmbedServer()).thenReturn(embedded);
+
+        webPluginActivator.stop(pluginContext);
+        verify(embeddedServerService, times(2)).getEmbedServer();
+        verify(embedded, times(1)).destroy();
+
+        doThrow(new LifecycleException()).when(embedded).destroy();
+        webPluginActivator.stop(pluginContext);
+        verify(embeddedServerService, times(4)).getEmbedServer();
+        verify(embedded, times(2)).destroy();
+
+        when(embeddedServerService.getEmbedServer()).thenReturn(new Object());
+        webPluginActivator.stop(pluginContext);
+        verify(embeddedServerService, times(5)).getEmbedServer();
+        verify(embedded, times(2)).destroy();
+    }
+}

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/test/java/com/alipay/sofa/ark/web/embed/bes/ArkBesEmbeddedWebappClassLoaderTest.java
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/test/java/com/alipay/sofa/ark/web/embed/bes/ArkBesEmbeddedWebappClassLoaderTest.java
@@ -1,0 +1,148 @@
+package com.alipay.sofa.ark.web.embed.bes;
+
+import com.bes.enterprise.webtier.LifecycleException;
+import com.bes.enterprise.webtier.WebResource;
+import com.bes.enterprise.webtier.WebResourceRoot;
+import com.bes.enterprise.webtier.loader.ResourceEntry;
+import com.bes.enterprise.webtier.loader.WebappClassLoaderBase;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.util.concurrent.ConcurrentHashMap;
+
+import static com.bes.enterprise.webtier.LifecycleState.STARTED;
+import static org.junit.Assert.*;
+import static org.mockito.Mockito.*;
+
+public class ArkBesEmbeddedWebappClassLoaderTest {
+
+    private ArkBesEmbeddedWebappClassLoader arkBesEmbeddedWebappClassLoader = new ArkBesEmbeddedWebappClassLoader();
+
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void loadClass() throws ClassNotFoundException, LifecycleException {
+        // 1) Test load class from current class loader's parent
+        assertEquals(String.class,arkBesEmbeddedWebappClassLoader.loadClass(String.class.getName(),true));
+        // 2) Test load class from current class loader's parent , which is null.
+        ArkBesEmbeddedWebappClassLoader arkBesEmbeddedWebappClassLoader2 =  new ArkBesEmbeddedWebappClassLoader();
+        try{
+            Field field = WebappClassLoaderBase.class.getDeclaredField("parent");
+            field.setAccessible(true);
+            field.set(arkBesEmbeddedWebappClassLoader2,null);
+            arkBesEmbeddedWebappClassLoader2.loadClass(String.class.getName(), true);
+            assertFalse(true);
+        }catch(Exception e){
+            if(e instanceof ClassNotFoundException){
+                // we expected ClassNotFoundException is thrown here,so we do nothing.
+            }else{
+                throw new RuntimeException(e);
+            }
+        }
+
+        // 3) Test load class without web class loader class cache.
+        try {
+            Field field = WebappClassLoaderBase.class.getDeclaredField("state");
+            field.setAccessible(true);
+            field.set(arkBesEmbeddedWebappClassLoader,STARTED);
+        }catch(Exception e){
+            throw new RuntimeException(e);
+        }
+        WebResourceRoot webResourceRoot = mock(WebResourceRoot.class);
+        WebResource webResource = mock(WebResource.class);
+        String path = "/"+this.getClass().getName().replace(".","/")+".class";
+        when(webResourceRoot.getClassLoaderResource(path)).thenReturn(webResource);
+        arkBesEmbeddedWebappClassLoader.setResources(webResourceRoot);
+
+        assertEquals(this.getClass(),
+                arkBesEmbeddedWebappClassLoader.loadClass(this.getClass().getName(),true));
+        verify(webResourceRoot,times(1)).getClassLoaderResource(path);
+        //note: exists always return false to mock resource not found and fallback to parent class loader.
+        verify(webResource, times(1)).exists();
+
+        // 4) Test load class with web class loader class cache.
+        ConcurrentHashMap<String, ResourceEntry> resourceEntries = new ConcurrentHashMap<>();
+        path = "/a/b.class";
+        try{
+            Field field = WebappClassLoaderBase.class.getDeclaredField("resourceEntries");
+            field.setAccessible(true);
+            ResourceEntry resourceEntry = new ResourceEntry();
+            resourceEntry.loadedClass = this.getClass();
+            resourceEntries.put(path,resourceEntry);
+            field.set(arkBesEmbeddedWebappClassLoader,resourceEntries);
+        }catch (Exception e){
+            throw new RuntimeException(e);
+        }
+        assertEquals(this.getClass(), arkBesEmbeddedWebappClassLoader.loadClass("a.b",true));
+
+        // 5) Test load class with delegate TRUE.
+        arkBesEmbeddedWebappClassLoader.setDelegate(true);
+        assertEquals(String.class,
+                arkBesEmbeddedWebappClassLoader.loadClass(String.class.getName(),true));
+        assertEquals(this.getClass(),arkBesEmbeddedWebappClassLoader.loadClass("a.b", false));
+
+        // 6) Test load class with delegate FALSE.
+        arkBesEmbeddedWebappClassLoader.setDelegate(false);
+        assertEquals(WebappClassLoaderBase.class,
+                arkBesEmbeddedWebappClassLoader.loadClass(WebappClassLoaderBase.class.getName(),true));
+        ResourceEntry resourceEntry = new ResourceEntry();
+        resourceEntry.loadedClass = String.class;
+        resourceEntries.put("/org/apache.class",resourceEntry);
+        assertEquals(String.class,
+                arkBesEmbeddedWebappClassLoader.loadClass("org.apache",false));
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testLoadClassNotFound() throws ClassNotFoundException{
+        assertEquals(this.getClass(),arkBesEmbeddedWebappClassLoader.loadClass("a.b",true));
+    }
+
+    @Test
+    public void testOtherMethods() throws IOException, ClassNotFoundException {
+
+        new ArkBesEmbeddedWebappClassLoader(this.getClass().getClassLoader());
+
+        assertNull(arkBesEmbeddedWebappClassLoader.findResource("aaa"));
+
+        assertEquals(false, arkBesEmbeddedWebappClassLoader.findResources("aaa")
+                .hasMoreElements());
+
+        arkBesEmbeddedWebappClassLoader.addURL(null);
+
+        try {
+            Field field = WebappClassLoaderBase.class.getDeclaredField("securityManager");
+            field.setAccessible(true);
+            field.set(arkBesEmbeddedWebappClassLoader, new SecurityManager());
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+        arkBesEmbeddedWebappClassLoader.checkPackageAccess(String.class.getName());
+        arkBesEmbeddedWebappClassLoader.checkPackageAccess("java"); // cover wrong class name
+    }
+
+    @Test(expected = ClassNotFoundException.class)
+    public void testCheckPackageAccessFailed() throws IOException, ClassNotFoundException {
+
+        SecurityManager securityManager = mock(SecurityManager.class);
+        doThrow(new SecurityException()).when(securityManager).checkPackageAccess("a");
+
+        try {
+            Field field = WebappClassLoaderBase.class.getDeclaredField("securityManager");
+            field.setAccessible(true);
+            field.set(arkBesEmbeddedWebappClassLoader, securityManager);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+
+        arkBesEmbeddedWebappClassLoader.checkPackageAccess("a.b");
+    }
+}

--- a/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/test/java/com/alipay/sofa/ark/web/embed/bes/EmbeddedServerServiceImplTest.java
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/bes-web-ark-plugin/src/test/java/com/alipay/sofa/ark/web/embed/bes/EmbeddedServerServiceImplTest.java
@@ -1,0 +1,36 @@
+package com.alipay.sofa.ark.web.embed.bes;
+
+import com.bes.enterprise.web.Embedded;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class EmbeddedServerServiceImplTest {
+
+    private EmbeddedServerServiceImpl embeddedServerServiceImpl = new EmbeddedServerServiceImpl();
+    @Before
+    public void setUp() throws Exception {
+    }
+
+    @After
+    public void tearDown() throws Exception {
+    }
+
+    @Test
+    public void setEmbedServer() {
+
+        embeddedServerServiceImpl.setEmbedServer(null);
+        assertEquals(null, embeddedServerServiceImpl.getEmbedServer());
+
+        Embedded embedded = new Embedded();
+        embeddedServerServiceImpl.setEmbedServer(embedded);
+        assertEquals(embedded, embeddedServerServiceImpl.getEmbedServer());
+
+        Embedded embedded2 = new Embedded();
+        embeddedServerServiceImpl.setEmbedServer(embedded2);
+        // should be still old one
+        assertEquals(embedded, embeddedServerServiceImpl.getEmbedServer());
+    }
+}

--- a/koupleless-adapter-web-bes/bes9-web-adapter/pom.xml
+++ b/koupleless-adapter-web-bes/bes9-web-adapter/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.alipay.sofa</groupId>
+    <artifactId>bes9-web-adapter</artifactId>
+    <version>2.2.14</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>bes-web-ark-plugin</module>
+        <module>bes-sofa-ark-springboot-starter</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/koupleless-adapter-web-tongweb/README.md
+++ b/koupleless-adapter-web-tongweb/README.md
@@ -1,0 +1,89 @@
+# koupleless-adapter-tongweb
+组件是作为 [Koupleless](https://github.com/koupleless/koupleless) 项目的一个扩展组件，目的是适配东方通（TongWEB)容器。
+
+由于 TongWEB 是商业软件，在该仓库中无法直接引入，所以需要本地已经有 TongWEB 依赖包。
+
+项目目前仅在tongweb-embed-7.0.E.6_P7 版本中验证过，其他版本需要自行验证，必要的话需要根据相同的思路进行调整。
+
+如果不需要使用同一端口来安装BIZ模块,只需要关注下文安装依赖章节提到的注意事项即可，不需要引入本项目相关的依赖。
+
+## 快速开始
+### 1. 安装依赖
+首先需要确保已经在 maven 仓库中导入了 TongWEB 相关的依赖，参考导入脚本如下：
+```shell
+mvn install:install-file -DgroupId=com.tongweb.springboot -DartifactId=tongweb-spring-boot-starter -Dversion=7.0.E.6_P7 -Dfile="XXX/tongweb-spring-boot-starter-7.0.E.6_P7.jar" -Dpackaging=jar
+mvn install:install-file -DgroupId=com.tongweb -DartifactId=tongweb-embed-core -Dversion=7.0.E.6_P7 -Dfile="XXX/tongweb-embed-core-7.0.E.6_P7.jar" -Dpackaging=jar
+mvn install:install-file -DgroupId=com.tongweb -DartifactId=tongweb-lic-sdk -Dversion=4.5.0.0 -Dfile="XXX/tongweb-lic-sdk-4.5.0.0.jar" -Dpackaging=jar
+```
+
+### 2. 编译安装本项目插件
+进入本项目的 tongweb7-web-adapter 目录执行 `mvn install` 命令即可。
+项目将会安装 tongweb7-web-ark-plugin 和 tongweb7-sofa-ark-springboot-starter 两个模块。
+
+### 3. 使用本项目组件
+首先需要根据koupleless的文档，[将项目升级为Koupleless基座](https://koupleless.io/docs/tutorials/base-create/springboot-and-sofaboot/)
+
+然后将依赖中提到的
+```xml
+    <dependency>
+        <groupId>com.alipay.sofa</groupId>
+        <artifactId>web-ark-plugin</artifactId>
+        <version>${sofa.ark.version}</version>
+    </dependency>
+```
+替换为本项目的坐标
+```xml
+    <dependency>
+        <groupId>com.alipay.sofa</groupId>
+        <artifactId>tongweb7-web-ark-plugin</artifactId>
+        <version>${sofa.ark.version}</version>
+    </dependency>
+    
+    <dependency>
+        <groupId>com.alipay.sofa</groupId>
+        <artifactId>tongweb7-sofa-ark-springboot-starter</artifactId>
+        <version>${sofa.ark.version}</version>
+    </dependency>
+```
+
+引入TongWEB相关依赖（同时需要exclude tomcat的依赖）。参考依赖如下：
+```xml
+       <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-tomcat</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>com.tongweb.springboot</groupId>
+            <artifactId>tongweb-spring-boot-starter</artifactId>
+            <version>7.0.E.6_P7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.tongweb</groupId>
+            <artifactId>tongweb-embed-core</artifactId>
+            <version>7.0.E.6_P7</version>
+        </dependency>
+        <dependency>
+            <groupId>com.tongweb</groupId>
+            <artifactId>tongweb-lic-sdk</artifactId>
+            <version>4.5.0.0</version>
+        </dependency>
+```
+
+### 4. 基座中增加宝蓝德特殊配置
+为什么需要这个配置， 是因为 koupleless其中 SOFAArk组件对于依赖包的识别机制与BES的包结构冲突，[参考这里](https://github.com/sofastack/sofa-ark/pull/997)
+
+需要在基座根目录 ark 配置文件中（`conf/ark/bootstrap.properties` 或 `conf/ark/bootstrap.yml`）增加白名单
+
+```properties
+declared.libraries.whitelist=com.tongweb.springboot:tongweb-spring-boot-starter,com.tongweb:tongweb-embed-core,com.tongweb:tongweb-lic-sdk
+```
+
+### 5. 完成
+完成上述步骤后，即可在 Koupleless 基座和模块中使用 TongWEB 启动项目。

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/pom.xml
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/pom.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.alipay.sofa</groupId>
+    <artifactId>tongweb7-web-adapter</artifactId>
+    <version>2.2.14</version>
+    <packaging>pom</packaging>
+    <modules>
+        <module>tongweb7-sofa-ark-springboot-starter</module>
+        <module>tongweb7-web-ark-plugin</module>
+    </modules>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+</project>

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/pom.xml
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/pom.xml
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.alipay.sofa</groupId>
+    <artifactId>tongweb7-sofa-ark-springboot-starter</artifactId>
+    <version>2.2.14</version>
+
+    <properties>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+        <spring.boot.version>2.7.14</spring.boot.version>
+        <sofa.ark.version>2.2.14</sofa.ark.version>
+        <junit.version>4.13.1</junit.version>
+        <reactor-netty.version>0.9.19.RELEASE</reactor-netty.version>
+    </properties>
+
+    <dependencies>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-autoconfigure</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-support-starter</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-api</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-compatible-springboot1</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-compatible-springboot2</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-logging</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <artifactId>log4j-over-slf4j</artifactId>
+                    <groupId>org.slf4j</groupId>
+                </exclusion>
+                <exclusion>
+                    <artifactId>logback-classic</artifactId>
+                    <groupId>ch.qos.logback</groupId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+
+        <!--junit-->
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+            <version>2.17.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-loader</artifactId>
+            <version>${spring.boot.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>io.projectreactor.netty</groupId>
+            <artifactId>reactor-netty</artifactId>
+            <version>${reactor-netty.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <!-- tongweb -->
+        <dependency>
+            <groupId>com.tongweb</groupId>
+            <artifactId>sofa-ark-tongweb-embed-core</artifactId>
+            <version>7.0.E.6_P7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tongweb</groupId>
+            <artifactId>sofa-ark-tongweb-lic-sdk</artifactId>
+            <version>4.5.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tongweb.springboot</groupId>
+            <artifactId>sofa-ark-tongweb-spring-boot-starter</artifactId>
+            <version>7.0.E.6_P7</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <threadCount>1</threadCount>
+                    <properties>
+                        <junit>false</junit>
+                    </properties>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/ArkTongWebServletLegacyAutoConfiguration.java
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/ArkTongWebServletLegacyAutoConfiguration.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.springboot;
+
+import com.alipay.sofa.ark.springboot.condition.ConditionalOnArkEnabled;
+import com.alipay.sofa.ark.springboot.web.ArkTongWebServletWebServerFactory;
+import com.tongweb.connector.UpgradeProtocol;
+import com.tongweb.container.startup.ServletContainer;
+import com.tongweb.springboot.servlet.LiteTongWeb;
+import com.tongweb.springboot.starter.TongWebServletWebServerFactory;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.SearchStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.servlet.Servlet;
+
+/**
+ * adapt to springboot 2.1.9.RELEASE
+ * @author chenjian
+ */
+@Configuration
+@ConditionalOnArkEnabled
+@ConditionalOnClass(LiteTongWeb.class)
+@AutoConfigureBefore(LiteTongWeb.class)
+public class ArkTongWebServletLegacyAutoConfiguration {
+    @Configuration
+    @ConditionalOnClass(value = { Servlet.class, ServletContainer.class, UpgradeProtocol.class,
+            TongWebServletWebServerFactory.class }, name = { "com.alipay.sofa.ark.web.embed.tongweb.ArkTongWebEmbeddedWebappClassLoader" })
+    @ConditionalOnMissingBean(value = TongWebServletWebServerFactory.class, search = SearchStrategy.CURRENT)
+    public static class EmbeddedArkTongWeb {
+
+        @Bean
+        @ConditionalOnMissingBean(ArkTongWebServletWebServerFactory.class)
+        public TongWebServletWebServerFactory tongWebServletWebServerFactory() {
+            return new ArkTongWebServletWebServerFactory();
+        }
+    }
+}

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/web/ArkTongWebServer.java
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/web/ArkTongWebServer.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.springboot.web;
+
+import com.tongweb.container.*;
+import com.tongweb.container.connector.Connector;
+import com.tongweb.container.startup.ServletContainer;
+import com.tongweb.naming.ContextBindings;
+import com.tongweb.springboot.starter.ConnectorStartFailedException;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.boot.web.server.WebServerException;
+import org.springframework.util.Assert;
+
+import javax.naming.NamingException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * NOTE: WebServer instance will start immediately when create ArkServletContainer object.
+ *
+ * @author chenjian
+ */
+public class ArkTongWebServer implements WebServer {
+
+    private static final Log                logger            = LogFactory
+                                                                  .getLog(ArkTongWebServer.class);
+
+    private static final AtomicInteger      containerCounter  = new AtomicInteger(-1);
+
+    private final Object                    monitor           = new Object();
+
+    private final Map<Service, Connector[]> serviceConnectors = new HashMap<>();
+
+    private final ServletContainer          webServer;
+
+    private final boolean                   autoStart;
+
+    private volatile boolean                started;
+
+    private Thread                          awaitThread;
+
+    private ServletContainer                arkEmbedWebServer;
+
+    /**
+     * Create a new {@link ArkTongWebServer} instance.
+     * @param webServer the underlying TongWeb server
+     */
+    public ArkTongWebServer(ServletContainer webServer) {
+        this(webServer, true);
+    }
+
+    /**
+     * Create a new {@link ArkTongWebServer} instance.
+     * @param webServer the underlying Web server
+     * @param autoStart if the server should be started
+     */
+    public ArkTongWebServer(ServletContainer webServer, boolean autoStart) {
+        Assert.notNull(webServer, "TongWeb Server must not be null");
+        this.webServer = webServer;
+        this.autoStart = autoStart;
+        initialize();
+    }
+
+    public ArkTongWebServer(ServletContainer webServer, boolean autoStart,
+                            ServletContainer arkEmbedWebServer) {
+        this(webServer, autoStart);
+        this.arkEmbedWebServer = arkEmbedWebServer;
+    }
+
+    private void initialize() throws WebServerException {
+        logger.info("TongWeb initialized with port(s): " + getPortsDescription(false));
+        synchronized (this.monitor) {
+            try {
+                addInstanceIdToEngineName();
+
+                Context context = findContext();
+                context.addLifecycleListener((event) -> {
+                    if (context.equals(event.getSource())
+                            && Lifecycle.START_EVENT.equals(event.getType())) {
+                        // Remove service connectors so that protocol binding doesn't
+                        // happen when the service is started.
+                        removeServiceConnectors();
+                    }
+                });
+
+                // Start the server to trigger initialization listeners
+                this.webServer.start();
+
+                // We can re-throw failure exception directly in the main thread
+                rethrowDeferredStartupExceptions();
+
+                try {
+                    ContextBindings.bindClassLoader(context, context.getNamingToken(),
+                            Thread.currentThread().getContextClassLoader());
+                }
+                catch (NamingException ex) {
+                    // Naming is not enabled. Continue
+                }
+
+                // Unlike Jetty, all TongWeb threads are daemon threads. We create a
+                // blocking non-daemon to stop immediate shutdown
+                startDaemonAwaitThread();
+            }
+            catch (Exception ex) {
+                stopSilently();
+                throw new WebServerException("Unable to start webServer TongWeb", ex);
+            }
+        }
+    }
+
+    private Context findContext() {
+        for (Container child : this.webServer.getHost().findChildren()) {
+            if (child instanceof Context) {
+                if (child.getParentClassLoader().equals(
+                    Thread.currentThread().getContextClassLoader())) {
+                    return (Context) child;
+                }
+            }
+        }
+        throw new IllegalStateException("The host does not contain a Context");
+    }
+
+    private void addInstanceIdToEngineName() {
+        int instanceId = containerCounter.incrementAndGet();
+        if (instanceId > 0) { // We already have a TongWeb container, so just return the existing TongWeb.
+            Engine engine = this.webServer.getEngine();
+            engine.setName(engine.getName() + "-" + instanceId);
+        }
+    }
+
+    private void removeServiceConnectors() {
+        for (Service service : this.webServer.getServer().findServices()) {
+            Connector[] connectors = service.findConnectors().clone();
+            this.serviceConnectors.put(service, connectors);
+            for (Connector connector : connectors) {
+                service.removeConnector(connector);
+            }
+        }
+    }
+
+    private void rethrowDeferredStartupExceptions() throws Exception {
+        Container[] children = this.webServer.getHost().findChildren();
+        for (Container container : children) {
+            // just to check current biz status
+            if (container.getParentClassLoader() == Thread.currentThread().getContextClassLoader()) {
+                if (!LifecycleState.STARTED.equals(container.getState())) {
+                    throw new IllegalStateException(container + " failed to start");
+                }
+            }
+        }
+    }
+
+    private void startDaemonAwaitThread() {
+        awaitThread = new Thread("container-" + (containerCounter.get())) {
+
+            @Override
+            public void run() {
+                getServer().getServer().await();
+            }
+
+        };
+        awaitThread.setContextClassLoader(Thread.currentThread().getContextClassLoader());
+        awaitThread.setDaemon(false);
+        awaitThread.start();
+    }
+
+    @Override
+    public void start() throws WebServerException {
+        synchronized (this.monitor) {
+            if (this.started) {
+                return;
+            }
+            try {
+                addPreviouslyRemovedConnectors();
+                this.webServer.getConnector();
+                checkThatConnectorsHaveStarted();
+                this.started = true;
+                logger.info("TongWeb started on port(s): " + getPortsDescription(true)
+                            + " with context path '" + getContextPath() + "'");
+            } catch (ConnectorStartFailedException ex) {
+                stopSilently();
+                throw ex;
+            } catch (Exception ex) {
+                throw new WebServerException("Unable to start webServer TongWeb server", ex);
+            } finally {
+                Context context = findContext();
+                ContextBindings.unbindClassLoader(context, context.getNamingToken(), getClass()
+                    .getClassLoader());
+            }
+        }
+    }
+
+    void checkThatConnectorsHaveStarted() {
+        checkConnectorHasStarted(this.webServer.getConnector());
+        for (Connector connector : this.webServer.getService().findConnectors()) {
+            checkConnectorHasStarted(connector);
+        }
+    }
+
+    private void checkConnectorHasStarted(Connector connector) {
+        if (LifecycleState.FAILED.equals(connector.getState())) {
+            throw new ConnectorStartFailedException(connector.getPort());
+        }
+    }
+
+    public void stopSilently() {
+        stopContext();
+        try {
+            stopTongWebIfNecessary();
+        } catch (LifecycleException ex) {
+            // Ignore
+        }
+    }
+
+    private void stopContext() {
+        Context context = findContext();
+        getServer().getHost().removeChild(context);
+    }
+
+    private void stopTongWebIfNecessary() throws LifecycleException {
+        if (webServer != arkEmbedWebServer) {
+            webServer.destroy();
+        }
+        if(awaitThread!=null)awaitThread.stop();
+    }
+
+    void addPreviouslyRemovedConnectors() {
+        Service[] services = this.webServer.getServer().findServices();
+        for (Service service : services) {
+            Connector[] connectors = this.serviceConnectors.get(service);
+            if (connectors != null) {
+                for (Connector connector : connectors) {
+                    service.addConnector(connector);
+                    if (!this.autoStart) {
+                        stopProtocolHandler(connector);
+                    }
+                }
+                this.serviceConnectors.remove(service);
+            }
+        }
+    }
+
+    private void stopProtocolHandler(Connector connector) {
+        try {
+            connector.getProtocolHandler().stop();
+        } catch (Exception ex) {
+            logger.error("Cannot pause connector: ", ex);
+        }
+    }
+
+    Map<Service, Connector[]> getServiceConnectors() {
+        return this.serviceConnectors;
+    }
+
+    @Override
+    public void stop() throws WebServerException {
+        synchronized (this.monitor) {
+            boolean wasStarted = this.started;
+            try {
+                this.started = false;
+                try {
+                    stopContext();
+                    stopTongWebIfNecessary();
+                } catch (Throwable ex) {
+                    // swallow and continue
+                }
+            } catch (Exception ex) {
+                throw new WebServerException("Unable to stop webServer TongWeb", ex);
+            } finally {
+                if (wasStarted) {
+                    containerCounter.decrementAndGet();
+                }
+            }
+        }
+    }
+
+    private String getPortsDescription(boolean localPort) {
+        StringBuilder ports = new StringBuilder();
+        for (Connector connector : this.webServer.getService().findConnectors()) {
+            if (ports.length() != 0) {
+                ports.append(' ');
+            }
+            int port = localPort ? connector.getLocalPort() : connector.getPort();
+            ports.append(port).append(" (").append(connector.getScheme()).append(')');
+        }
+        return ports.toString();
+    }
+
+    @Override
+    public int getPort() {
+        Connector connector = this.webServer.getConnector();
+        if (connector != null) {
+            return connector.getLocalPort();
+        }
+        return 0;
+    }
+
+    private String getContextPath() {
+        return findContext().getPath();
+    }
+
+    /**
+     * Returns access to the underlying TongWeb server.
+     * @return the TongWeb server
+     */
+    public ServletContainer getServer() {
+        return this.webServer;
+    }
+
+}

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/web/ArkTongWebServletWebServerFactory.java
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/src/main/java/com/alipay/sofa/ark/springboot/web/ArkTongWebServletWebServerFactory.java
@@ -1,0 +1,492 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.springboot.web;
+
+import com.alipay.sofa.ark.common.util.AssertUtils;
+import com.alipay.sofa.ark.spi.model.Biz;
+import com.alipay.sofa.ark.spi.service.ArkInject;
+import com.alipay.sofa.ark.spi.service.biz.BizManagerService;
+import com.alipay.sofa.ark.spi.web.EmbeddedServerService;
+import com.tongweb.commons.license.LicenseSDKProvider;
+import com.tongweb.commons.utils.SystemExitUtil;
+import com.tongweb.container.*;
+import com.tongweb.container.connector.Connector;
+import com.tongweb.container.core.AprLifecycleListener;
+import com.tongweb.container.core.StandardContext;
+import com.tongweb.container.loader.WebappLoader;
+import com.tongweb.container.startup.ServletContainer;
+import com.tongweb.container.util.ServerInfo;
+import com.tongweb.container.valves.FilterValue;
+import com.tongweb.container.webresources.StandardRoot;
+import com.tongweb.springboot.properties.IoMode;
+import com.tongweb.springboot.properties.ManageWebProperties;
+import com.tongweb.springboot.properties.PropertyMapper;
+import com.tongweb.springboot.properties.TongWebProperties;
+import com.tongweb.springboot.starter.CheckIntegrityUtil;
+import com.tongweb.springboot.starter.TongWebServletWebServerFactory;
+import com.tongweb.web.util.modeler.Registry;
+import com.tongweb.web.util.scan.StandardJarScanFilter;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.ExitCodeGenerator;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.web.server.WebServer;
+import org.springframework.boot.web.servlet.ServletContextInitializer;
+import org.springframework.context.ApplicationContext;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ObjectUtils;
+import org.springframework.util.StringUtils;
+
+import javax.annotation.PostConstruct;
+import javax.servlet.ServletContainerInitializer;
+import java.io.File;
+import java.net.URL;
+import java.nio.charset.Charset;
+import java.nio.charset.StandardCharsets;
+import java.util.*;
+
+import static com.alipay.sofa.ark.spi.constant.Constants.ROOT_WEB_CONTEXT_PATH;
+
+/**
+ * @author chenjian
+ */
+public class ArkTongWebServletWebServerFactory extends TongWebServletWebServerFactory {
+
+    private static final Charset                    DEFAULT_CHARSET             = StandardCharsets.UTF_8;
+
+    @ArkInject
+    private EmbeddedServerService<ServletContainer> embeddedServerService;
+
+    @ArkInject
+    private BizManagerService                       bizManagerService;
+
+    private File                                    baseDirectory;
+
+    private String                                  protocol                    = DEFAULT_PROTOCOL;
+
+    private int                                     backgroundProcessorDelay;
+
+    private final List<Connector>                   additionalTongWebConnectors = new ArrayList();
+
+    @Autowired
+    private TongWebProperties                       tongWebProperties;
+    @Autowired
+    private ManageWebProperties                     manageWebProperties;
+    @Autowired
+    private ApplicationContext                      context;
+    private boolean                                 disableMBeanRegistry;
+    private Valve                                   filterValve;
+
+    public ArkTongWebServletWebServerFactory() {
+    }
+
+    @Override
+    public WebServer getWebServer(ServletContextInitializer... initializers) {
+        if (embeddedServerService == null && ArkClient.getInjectionService() != null) {
+            // 非应用上下文 (例如: Spring Management Context) 没有经历 Start 生命周期, 不会被注入 ArkServiceInjectProcessor,
+            // 因此 @ArkInject 没有被处理, 需要手动处理
+            ArkClient.getInjectionService().inject(this);
+        }
+        ServletContainer servletContainer;
+        if (embeddedServerService == null) {
+            return super.getWebServer(initializers);
+        } else if (embeddedServerService.getEmbedServer(getPort()) == null) {
+            embeddedServerService.putEmbedServer(getPort(), initEmbedWebServer(initializers));
+            servletContainer = (ServletContainer) embeddedServerService.getEmbedServer(getPort());
+        } else {
+            servletContainer = (ServletContainer) embeddedServerService.getEmbedServer(getPort());
+            prepareContext(servletContainer.getHost(), initializers);
+        }
+        return getWebServer(servletContainer);
+    }
+
+    @PostConstruct
+    private void init() {
+        this.initDisableMBeanRegistry();
+        if (!StringUtils.isEmpty(this.manageWebProperties.getContextPath())
+            && (!StringUtils.isEmpty(this.manageWebProperties.getAccess_iplist()) || !StringUtils
+                .isEmpty(this.manageWebProperties.getBlocked_iplist()))) {
+            this.filterValve = new FilterValue(this.manageWebProperties.convertProp());
+        }
+
+    }
+
+    private void initDisableMBeanRegistry() {
+        this.disableMBeanRegistry = !this.tongWebProperties.getTongweb().getMbeanregistry()
+            .isEnabled();
+    }
+
+    @Override
+    public String getContextPath() {
+        String contextPath = super.getContextPath();
+        if (bizManagerService == null) {
+            return contextPath;
+        }
+        Biz biz = bizManagerService.getBizByClassLoader(Thread.currentThread()
+            .getContextClassLoader());
+        if (!StringUtils.isEmpty(contextPath)) {
+            return contextPath;
+        } else if (biz != null) {
+            if (StringUtils.isEmpty(biz.getWebContextPath())) {
+                return ROOT_WEB_CONTEXT_PATH;
+            }
+            return biz.getWebContextPath();
+        } else {
+            return ROOT_WEB_CONTEXT_PATH;
+        }
+    }
+
+    private ServletContainer initEmbedWebServer(ServletContextInitializer... initializers) {
+        System.setProperty("java.security.egd", "file:/dev/./urandom");
+        this.addExitHook();
+        this.processLicenseValidateConfig();
+        if (!ObjectUtils
+            .isEmpty(this.tongWebProperties.getTongweb().getAdditionalTldSkipPatterns())) {
+            this.getTldSkipPatterns().addAll(
+                this.tongWebProperties.getTongweb().getAdditionalTldSkipPatterns());
+        }
+
+        if (this.disableMBeanRegistry) {
+            Registry.disableRegistry();
+        }
+
+        ServletContainer servletContainer = new ServletContainer();
+        File baseDir = this.baseDirectory != null ? this.baseDirectory : this
+            .createTempDir("tongweb");
+        servletContainer.setBaseDir(baseDir.getAbsolutePath());
+        if (this.protocol.equalsIgnoreCase(IoMode.APR.getClassName())) {
+            LifecycleListener arpLifecycle = new AprLifecycleListener();
+            this.addContextLifecycleListeners(arpLifecycle);
+        }
+
+        Connector connector = new Connector(this.protocol);
+        servletContainer.getService().addConnector(connector);
+        this.customizeConnector(connector);
+        servletContainer.setConnector(connector);
+        servletContainer.getHost().setAutoDeploy(false);
+        this.configureEngine(servletContainer.getEngine());
+        this.configureAccessLog(servletContainer.getHost());
+        this.configureSemaphore(servletContainer.getHost());
+        this.configureFilterValue(servletContainer.getHost());
+        this.configureRemoteFilter(servletContainer.getHost());
+        Iterator var5 = this.additionalTongWebConnectors.iterator();
+
+        while (var5.hasNext()) {
+            Connector additionalConnector = (Connector) var5.next();
+            servletContainer.getService().addConnector(additionalConnector);
+        }
+
+        this.prepareContext(servletContainer.getHost(), initializers);
+        this.configureWebApps(servletContainer);
+        this.configureWar(servletContainer);
+        return servletContainer;
+    }
+
+    private void configureFilterValue(Host host) {
+        if (this.getFilterValve() != null) {
+            host.getPipeline().addValve(this.getFilterValve());
+        }
+
+    }
+
+    private void configureAccessLog(Host host) {
+        if (this.getAccessLog() != null) {
+            host.getPipeline().addValve(this.getAccessLog());
+        }
+
+    }
+
+    private void configureSemaphore(Host host) {
+        if (this.getSemaphore() != null) {
+            host.getPipeline().addValve(this.getSemaphore());
+        }
+
+    }
+
+    private void addExitHook() {
+        SystemExitUtil.setHook(() -> {
+            System.exit(SpringApplication.exit(this.context, new ExitCodeGenerator[]{() -> {
+                return 0;
+            }}));
+        });
+    }
+
+    private void putLicenseIps(String value) {
+        System.setProperty("server.tongweb.license.license-ips", value);
+    }
+
+    private void putPublicKey(String value) {
+        System.setProperty("server.tongweb.license.publicKey", value);
+    }
+
+    private void putProductKey(String value) {
+        System.setProperty("server.tongweb.license.productKey", value);
+    }
+
+    private void putTongwebEdition(String value) {
+        System.setProperty("server.tongweb.license.tongWebEdition", value);
+    }
+
+    private void pusSslEnabled(boolean value) {
+        System.setProperty("server.tongweb.license.ssl.enabled", String.valueOf(value));
+    }
+
+    private void putKeyStore(String value) {
+        System.setProperty("server.tongweb.license.ssl.keyStore", value);
+    }
+
+    private void putKeyStorePassword(String value) {
+        System.setProperty("server.tongweb.license.ssl.keyStorePassword", value);
+    }
+
+    private void putKeyStoreType(String value) {
+        System.setProperty("server.tongweb.license.ssl.keyStoreType", value);
+    }
+
+    private void putTrustStore(String value) {
+        System.setProperty("server.tongweb.license.ssl.trustStore", value);
+    }
+
+    private void putTrustStorePassword(String value) {
+        System.setProperty("server.tongweb.license.ssl.trustStorePassword", value);
+    }
+
+    private void putTrustStoreType(String value) {
+        System.setProperty("server.tongweb.license.ssl.trustStoreType", value);
+    }
+
+    private void processLicenseValidateConfig() {
+        ServerInfo.getServerENumber();
+        new CheckIntegrityUtil();
+        PropertyMapper propertyMapper = PropertyMapper.get();
+        String validType = this.tongWebProperties.getTongweb().getLicense().getType();
+        String licensePath = this.tongWebProperties.getTongweb().getLicense().getPath();
+        Boolean isSync = this.tongWebProperties.getTongweb().getLicense().isSync();
+        System.setProperty("server.tongweb.license.type", validType);
+        System.setProperty("server.tongweb.license.filePath", licensePath);
+        System.setProperty("server.tongweb.license.isSync", isSync.toString());
+        propertyMapper.from(this.tongWebProperties.getTongweb().getLicense().getLicenseIps()).whenHasText().to(this::putLicenseIps);
+        propertyMapper.from(this.tongWebProperties.getTongweb().getLicense().getLicensePublicKey()).whenHasText().to(this::putPublicKey);
+        if (this.tongWebProperties.getTongweb().getLicense().getSsl() != null) {
+            propertyMapper.from(this.tongWebProperties.getTongweb().getLicense().isSslEnabled()).whenNonNull().to(this::pusSslEnabled);
+            propertyMapper.from(this.tongWebProperties.getTongweb().getLicense().getSsl().getKeyStore()).whenHasText().to(this::putKeyStore);
+            propertyMapper.from(this.tongWebProperties.getTongweb().getLicense().getSsl().getKeyStorePassword()).whenHasText().to(this::putKeyStorePassword);
+            propertyMapper.from(this.tongWebProperties.getTongweb().getLicense().getSsl().getKeyStoreType()).whenHasText().to(this::putKeyStoreType);
+            propertyMapper.from(this.tongWebProperties.getTongweb().getLicense().getSsl().getTrustStore()).whenHasText().to(this::putTrustStore);
+            propertyMapper.from(this.tongWebProperties.getTongweb().getLicense().getSsl().getTrustStorePassword()).whenHasText().to(this::putTrustStorePassword);
+            propertyMapper.from(this.tongWebProperties.getTongweb().getLicense().getSsl().getTrustStoreType()).whenHasText().to(this::putTrustStoreType);
+        }
+
+        LicenseSDKProvider.validate();
+    }
+
+    @Override
+    public void setBaseDirectory(File baseDirectory) {
+        this.baseDirectory = baseDirectory;
+    }
+
+    /**
+     * The tongweb protocol to use when create the {@link Connector}.
+     * @param protocol the protocol
+     * @see Connector#Connector(String)
+     */
+    @Override
+    public void setProtocol(String protocol) {
+        AssertUtils.isFalse(StringUtils.isEmpty(protocol), "Protocol must not be empty");
+        this.protocol = protocol;
+    }
+
+    @Override
+    public void setBackgroundProcessorDelay(int delay) {
+        this.backgroundProcessorDelay = delay;
+    }
+
+    private void configureEngine(Engine engine) {
+        engine.setBackgroundProcessorDelay(this.backgroundProcessorDelay);
+        for (Valve valve : getEngineValves()) {
+            engine.getPipeline().addValve(valve);
+        }
+    }
+
+    @Override
+    protected void postProcessContext(Context context) {
+        ((WebappLoader) context.getLoader())
+            .setLoaderClass("com.alipay.sofa.ark.web.embed.tongweb.ArkTongWebEmbeddedWebappClassLoader");
+    }
+
+    @Override
+    protected void prepareContext(Host host, ServletContextInitializer[] initializers) {
+        if (host.getState() == LifecycleState.NEW) {
+            super.prepareContext(host, initializers);
+        } else {
+            File documentRoot = getValidDocumentRoot();
+            StandardContext context = new StandardContext();
+            if (documentRoot != null) {
+                context.setResources(new StandardRoot(context));
+            }
+            context.setName(getContextPath());
+            context.setDisplayName(getDisplayName());
+            context.setPath(getContextPath());
+            File docBase = (documentRoot != null) ? documentRoot : createTempDir("tongweb-docbase");
+            context.setDocBase(docBase.getAbsolutePath());
+            context.addLifecycleListener(new ServletContainer.FixContextListener());
+            context.setParentClassLoader(Thread.currentThread().getContextClassLoader());
+            resetDefaultLocaleMapping(context);
+            addLocaleMappings(context);
+            context.setUseRelativeRedirects(false);
+            configureTldSkipPatterns(context);
+            WebappLoader loader = new WebappLoader();
+            loader
+                .setLoaderClass("com.alipay.sofa.ark.web.embed.tongweb.ArkTongWebEmbeddedWebappClassLoader");
+            loader.setDelegate(true);
+            context.setLoader(loader);
+            if (isRegisterDefaultServlet()) {
+                addDefaultServlet(context);
+            }
+            if (shouldRegisterJspServlet()) {
+                addJspServlet(context);
+                addJasperInitializer(context);
+            }
+            context.addLifecycleListener(new StaticResourceConfigurer(context));
+            ServletContextInitializer[] initializersToUse = mergeInitializers(initializers);
+            context.setParent(host);
+            configureContext(context, initializersToUse);
+            host.addChild(context);
+        }
+    }
+
+    /**
+     * Override tongweb's default locale mappings to align with other servers. See
+     * {@code org.apache.catalina.util.CharsetMapperDefault.properties}.
+     * @param context the context to reset
+     */
+    private void resetDefaultLocaleMapping(StandardContext context) {
+        context.addLocaleEncodingMappingParameter(Locale.ENGLISH.toString(),
+            DEFAULT_CHARSET.displayName());
+        context.addLocaleEncodingMappingParameter(Locale.FRENCH.toString(),
+            DEFAULT_CHARSET.displayName());
+    }
+
+    private void addLocaleMappings(StandardContext context) {
+        for (Map.Entry<Locale, Charset> entry : getLocaleCharsetMappings().entrySet()) {
+            context.addLocaleEncodingMappingParameter(entry.getKey().toString(), entry.getValue()
+                .toString());
+        }
+    }
+
+    private void configureTldSkipPatterns(StandardContext context) {
+        StandardJarScanFilter filter = new StandardJarScanFilter();
+        filter.setTldSkip(StringUtils.collectionToCommaDelimitedString(getTldSkipPatterns()));
+        context.getJarScanner().setJarScanFilter(filter);
+    }
+
+    private void addDefaultServlet(Context context) {
+        Wrapper defaultServlet = context.createWrapper();
+        defaultServlet.setName("default");
+        defaultServlet.setServletClass("com.tongweb.container.servlets.DefaultServlet");
+        defaultServlet.addInitParameter("debug", "0");
+        defaultServlet.addInitParameter("listings", "false");
+        defaultServlet.setLoadOnStartup(1);
+        // Otherwise the default location of a Spring DispatcherServlet cannot be set
+        defaultServlet.setOverridable(true);
+        context.addChild(defaultServlet);
+        context.addServletMappingDecoded("/", "default");
+    }
+
+    private void addJspServlet(Context context) {
+        Wrapper jspServlet = context.createWrapper();
+        jspServlet.setName("jsp");
+        jspServlet.setServletClass(getJsp().getClassName());
+        jspServlet.addInitParameter("fork", "false");
+        for (Map.Entry<String, String> entry : getJsp().getInitParameters().entrySet()) {
+            jspServlet.addInitParameter(entry.getKey(), entry.getValue());
+        }
+        jspServlet.setLoadOnStartup(3);
+        context.addChild(jspServlet);
+        context.addServletMappingDecoded("*.jsp", "jsp");
+        context.addServletMappingDecoded("*.jspx", "jsp");
+    }
+
+    private void addJasperInitializer(StandardContext context) {
+        try {
+            ServletContainerInitializer initializer = (ServletContainerInitializer) ClassUtils
+                .forName("org.apache.jasper.servlet.JasperInitializer", null).newInstance();
+            context.addServletContainerInitializer(initializer, null);
+        } catch (Exception ex) {
+            // Probably not tongweb other version
+        }
+    }
+
+    final class StaticResourceConfigurer implements LifecycleListener {
+
+        private final Context context;
+
+        private StaticResourceConfigurer(Context context) {
+            this.context = context;
+        }
+
+        @Override
+        public void lifecycleEvent(LifecycleEvent event) {
+            if (event.getType().equals(Lifecycle.CONFIGURE_START_EVENT)) {
+                addResourceJars(getUrlsOfJarsWithMetaInfResources());
+            }
+        }
+
+        private void addResourceJars(List<URL> resourceJarUrls) {
+            for (URL url : resourceJarUrls) {
+                String path = url.getPath();
+                if (path.endsWith(".jar") || path.endsWith(".jar!/")) {
+                    String jar = url.toString();
+                    if (!jar.startsWith("jar:")) {
+                        // A jar file in the file system. Convert to Jar URL.
+                        jar = "jar:" + jar + "!/";
+                    }
+                    addResourceSet(jar);
+                } else {
+                    addResourceSet(url.toString());
+                }
+            }
+        }
+
+        private void addResourceSet(String resource) {
+            try {
+                if (isInsideNestedJar(resource)) {
+                    // It's a nested jar but we now don't want the suffix because tongweb
+                    // is going to try and locate it as a root URL (not the resource
+                    // inside it)
+                    resource = resource.substring(0, resource.length() - 2);
+                }
+                URL url = new URL(resource);
+                String path = "/META-INF/resources";
+                this.context.getResources().createWebResourceSet(
+                    WebResourceRoot.ResourceSetType.RESOURCE_JAR, "/", url, path);
+            } catch (Exception ex) {
+                // Ignore (probably not a directory)
+            }
+        }
+
+        private boolean isInsideNestedJar(String dir) {
+            return dir.indexOf("!/") < dir.lastIndexOf("!/");
+        }
+    }
+
+    /**
+     * additional processing to the tongweb server.
+     */
+    protected WebServer getWebServer(ServletContainer embedded) {
+        return new ArkTongWebServer(embedded, getPort() >= 0, embedded);
+    }
+}

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/src/main/resources/META-INF/spring.factories
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-sofa-ark-springboot-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+com.alipay.sofa.ark.springboot.ArkTongWebServletLegacyAutoConfiguration

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-web-ark-plugin/pom.xml
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-web-ark-plugin/pom.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>com.alipay.sofa</groupId>
+    <artifactId>tongweb7-web-ark-plugin</artifactId>
+    <version>2.2.14</version>
+
+    <properties>
+        <sofa.ark.version>2.2.14</sofa.ark.version>
+        <mockito.version>3.6.0</mockito.version>
+        <junit.version>4.13.1</junit.version>
+        <maven.compiler.source>15</maven.compiler.source>
+        <maven.compiler.target>15</maven.compiler.target>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.tongweb.springboot</groupId>
+            <artifactId>sofa-ark-tongweb-spring-boot-starter</artifactId>
+            <version>7.0.E.6_P7</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.tongweb</groupId>
+            <artifactId>sofa-ark-tongweb-embed-core</artifactId>
+            <version>7.0.E.6_P7</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.tongweb</groupId>
+            <artifactId>sofa-ark-tongweb-lic-sdk</artifactId>
+            <version>4.5.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>sofa-ark-common</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+
+        <!-- Test Dependencies -->
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <version>${mockito.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>${junit.version}</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.alipay.sofa</groupId>
+                <artifactId>sofa-ark-plugin-maven-plugin</artifactId>
+                <version>${project.version}</version>
+                <executions>
+                    <execution>
+                        <id>default-cli</id>
+                        <goals>
+                            <goal>ark-plugin</goal>
+                        </goals>
+
+                        <configuration>
+                            <activator>com.alipay.sofa.ark.web.embed.TongWebPluginActivator</activator>
+                            <excludes>
+                                <exclude>*:*:*</exclude>
+                                <exclude>com.alipay.sofa:tongweb7-web-ark-plugin</exclude>
+                            </excludes>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+
+</project>

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/TongWebPluginActivator.java
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/TongWebPluginActivator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.web.embed;
+
+import com.alipay.sofa.ark.common.log.ArkLoggerFactory;
+import com.alipay.sofa.ark.spi.model.PluginContext;
+import com.alipay.sofa.ark.spi.service.PluginActivator;
+import com.alipay.sofa.ark.spi.web.EmbeddedServerService;
+import com.alipay.sofa.ark.web.embed.tongweb.EmbeddedServerServiceImpl;
+import com.tongweb.container.startup.ServletContainer;
+
+/**
+ * @author chenjian
+ */
+public class TongWebPluginActivator implements PluginActivator {
+    EmbeddedServerService embeddedServerService = new EmbeddedServerServiceImpl();
+
+    public TongWebPluginActivator() {
+    }
+
+    public void start(PluginContext context) {
+        context.publishService(EmbeddedServerService.class, this.embeddedServerService);
+    }
+
+    public void stop(PluginContext context) {
+    }
+}

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/tongweb/ArkTongWebEmbeddedWebappClassLoader.java
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/tongweb/ArkTongWebEmbeddedWebappClassLoader.java
@@ -1,0 +1,130 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.web.embed.tongweb;
+
+import com.alipay.sofa.ark.common.log.ArkLoggerFactory;
+import com.tongweb.container.loader.ParallelWebappClassLoader;
+import org.slf4j.Logger;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Collections;
+import java.util.Enumeration;
+
+/**
+ * @author chenjian
+ */
+public class ArkTongWebEmbeddedWebappClassLoader extends ParallelWebappClassLoader {
+    private static final Logger LOGGER = ArkLoggerFactory
+                                           .getLogger(ArkTongWebEmbeddedWebappClassLoader.class);
+
+    public ArkTongWebEmbeddedWebappClassLoader() {
+    }
+
+    public ArkTongWebEmbeddedWebappClassLoader(ClassLoader parent) {
+        super(parent);
+    }
+
+    public URL findResource(String name) {
+        return null;
+    }
+
+    public Enumeration<URL> findResources(String name) throws IOException {
+        return Collections.emptyEnumeration();
+    }
+
+    public Class<?> loadClass(String name, boolean resolve) throws ClassNotFoundException {
+        synchronized (this.getClassLoadingLock(name)) {
+            Class<?> result = this.findExistingLoadedClass(name);
+            result = result != null ? result : this.doLoadClass(name);
+            if (result == null) {
+                throw new ClassNotFoundException(name);
+            } else {
+                return this.resolveIfNecessary(result, resolve);
+            }
+        }
+    }
+
+    private Class<?> findExistingLoadedClass(String name) {
+        Class<?> resultClass = this.findLoadedClass0(name);
+        resultClass = resultClass != null ? resultClass : this.findLoadedClass(name);
+        return resultClass;
+    }
+
+    private Class<?> doLoadClass(String name) throws ClassNotFoundException {
+        this.checkPackageAccess(name);
+        Class result;
+        if (!this.delegate && !this.filter(name, true)) {
+            result = this.findClassIgnoringNotFound(name);
+            return result != null ? result : this.loadFromParent(name);
+        } else {
+            result = this.loadFromParent(name);
+            return result != null ? result : this.findClassIgnoringNotFound(name);
+        }
+    }
+
+    private Class<?> resolveIfNecessary(Class<?> resultClass, boolean resolve) {
+        if (resolve) {
+            this.resolveClass(resultClass);
+        }
+
+        return resultClass;
+    }
+
+    protected void addURL(URL url) {
+        if (LOGGER.isTraceEnabled()) {
+            LOGGER.trace("Ignoring request to add " + url + " to the TongWeb classloader");
+        }
+
+    }
+
+    private Class<?> loadFromParent(String name) {
+        if (this.parent == null) {
+            return null;
+        } else {
+            try {
+                return Class.forName(name, false, this.parent);
+            } catch (ClassNotFoundException var3) {
+                return null;
+            }
+        }
+    }
+
+    private Class<?> findClassIgnoringNotFound(String name) {
+        try {
+            return this.findClass(name);
+        } catch (ClassNotFoundException var3) {
+            return null;
+        }
+    }
+
+    void checkPackageAccess(String name) throws ClassNotFoundException {
+        if (this.securityManager != null && name.lastIndexOf(46) >= 0) {
+            try {
+                this.securityManager.checkPackageAccess(name.substring(0, name.lastIndexOf(46)));
+            } catch (SecurityException var3) {
+                throw new ClassNotFoundException(
+                    "Security Violation, attempt to use Restricted Class: " + name, var3);
+            }
+        }
+
+    }
+
+    static {
+        ClassLoader.registerAsParallelCapable();
+    }
+}

--- a/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/tongweb/EmbeddedServerServiceImpl.java
+++ b/koupleless-adapter-web-tongweb/tongweb7-web-adapter/tongweb7-web-ark-plugin/src/main/java/com/alipay/sofa/ark/web/embed/tongweb/EmbeddedServerServiceImpl.java
@@ -1,0 +1,26 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.ark.web.embed.tongweb;
+
+import com.alipay.sofa.ark.spi.web.AbstractEmbeddedServerService;
+import com.tongweb.container.startup.ServletContainer;
+
+/**
+ * @author chenjian
+ */
+public class EmbeddedServerServiceImpl extends AbstractEmbeddedServerService<ServletContainer> {
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced `koupleless-adapter-bes` and `koupleless-adapter-tongweb` components for integration with BES and TongWEB containers, respectively.
  - Added detailed installation and configuration guides in the README files for both components.
  - New classes for managing web server lifecycles and configurations for both BES and TongWEB.

- **Documentation**
  - Updated README files with quick start guides and compatibility notes for both components.

- **Tests**
  - Added unit tests for various classes to ensure functionality and error handling in both BES and TongWEB integrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->