### PR TITLE
feat: add adaptor for logback in spring-boot

### DIFF
--- a/koupleless-adapter-logback/src/main/java/ch/qos/logback/classic/Logger.java
+++ b/koupleless-adapter-logback/src/main/java/ch/qos/logback/classic/Logger.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+import ch.qos.logback.core.util.Loader;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
 import org.slf4j.impl.StaticLoggerBinder;
@@ -788,8 +789,11 @@ public final class Logger implements org.slf4j.Logger, LocationAwareLogger,
     public LoggerContext getLoggerContext() {
         // diff that made by koupleless, get loggerContext from loggerContextMap
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        return loggerContextMap.computeIfAbsent(classLoader,
+        LoggerContext loggerContext = loggerContextMap.computeIfAbsent(classLoader,
             k -> (LoggerContext) StaticLoggerBinder.getSingleton().getLoggerFactory());
+
+        Loader.registerLoggerContext(loggerContext);
+        return loggerContext;
     }
 
     public void log(Marker marker, String fqcn, int levelInt, String message, Object[] argArray,

--- a/koupleless-adapter-logback/src/main/java/ch/qos/logback/core/util/Loader.java
+++ b/koupleless-adapter-logback/src/main/java/ch/qos/logback/core/util/Loader.java
@@ -1,0 +1,218 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package ch.qos.logback.core.util;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.core.Context;
+
+import java.io.IOException;
+import java.net.URL;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Load resources (or images) from various sources.
+ *
+ * @author Ceki G&uuml;lc&uuml;
+ */
+public class Loader {
+    static final String                                  TSTR                            = "Caught Exception while in Loader.getResource. This may be innocuous.";
+
+    private static boolean                               ignoreTCL                       = false;
+    public static final String                           IGNORE_TCL_PROPERTY_NAME        = "logback.ignoreTCL";
+    private static boolean                               HAS_GET_CLASS_LOADER_PERMISSION = false;
+
+    /**
+     * diff that made by koupleless, add this map to store loggerContext for each biz module
+     */
+    private static final Map<LoggerContext, ClassLoader> loggerContextMap                = new ConcurrentHashMap<>();
+
+    static {
+        String ignoreTCLProp = OptionHelper.getSystemProperty(IGNORE_TCL_PROPERTY_NAME, null);
+
+        if (ignoreTCLProp != null) {
+            ignoreTCL = OptionHelper.toBoolean(ignoreTCLProp, true);
+        }
+
+        HAS_GET_CLASS_LOADER_PERMISSION = AccessController
+            .doPrivileged(new PrivilegedAction<Boolean>() {
+                public Boolean run() {
+                    try {
+                        AccessController.checkPermission(new RuntimePermission("getClassLoader"));
+                        return true;
+                    } catch (SecurityException e) {
+                        // Using SecurityException instead of AccessControlException.
+                        // See bug LOGBACK-760.
+                        return false;
+                    }
+                }
+            });
+    }
+
+    /**
+     * Compute the number of occurrences a resource can be found by a class
+     * loader.
+     *
+     * @param resource
+     * @param classLoader
+     * @return
+     * @throws IOException
+     */
+
+    public static Set<URL> getResources(String resource,
+                                        ClassLoader classLoader) throws IOException {
+        // See LBCLASSIC-159
+        Set<URL> urlSet = new HashSet<URL>();
+        Enumeration<URL> urlEnum = classLoader.getResources(resource);
+        while (urlEnum.hasMoreElements()) {
+            URL url = urlEnum.nextElement();
+            urlSet.add(url);
+        }
+        return urlSet;
+    }
+
+    /**
+     * Search for a resource using the classloader passed as parameter.
+     *
+     * @param resource    the resource name to look for
+     * @param classLoader the classloader used for the search
+     */
+    public static URL getResource(String resource, ClassLoader classLoader) {
+        try {
+            return classLoader.getResource(resource);
+        } catch (Throwable t) {
+            return null;
+        }
+    }
+
+    /**
+     * Attempt to find a resource by using the classloader that loaded this class,
+     * namely Loader.class.
+     *
+     * @param resource
+     * @return
+     */
+    public static URL getResourceBySelfClassLoader(String resource) {
+        return getResource(resource, getClassLoaderOfClass(Loader.class));
+    }
+
+    // private static URL getResourceByTCL(String resource) {
+    // return getResource(resource, getTCL());
+    // }
+
+    /**
+     * Get the Thread Context Loader which is a JDK 1.2 feature. If we are running
+     * under JDK 1.1 or anything else goes wrong the method returns
+     * <code>null<code>.
+     */
+    public static ClassLoader getTCL() {
+        return Thread.currentThread().getContextClassLoader();
+    }
+
+    public static Class<?> loadClass(String clazz, Context context) throws ClassNotFoundException {
+        ClassLoader cl = getClassLoaderOfObject(context);
+
+        // diff that made by koupleless, add this loggerContext to loggerContextMap
+        if (context instanceof LoggerContext
+            && loggerContextMap.containsKey((LoggerContext) context)) {
+            cl = loggerContextMap.get(context);
+        }
+
+        return cl.loadClass(clazz);
+    }
+
+    /**
+     * Get the class loader of the object passed as argument. Return the system
+     * class loader if appropriate.
+     *
+     * @param o
+     * @return
+     */
+    public static ClassLoader getClassLoaderOfObject(Object o) {
+        if (o == null) {
+            throw new NullPointerException("Argument cannot be null");
+        }
+        return getClassLoaderOfClass(o.getClass());
+    }
+
+    /**
+     * Returns the class loader of clazz in an access privileged section.
+     *
+     * @param clazz
+     * @return
+     */
+    public static ClassLoader getClassLoaderAsPrivileged(final Class<?> clazz) {
+        if (!HAS_GET_CLASS_LOADER_PERMISSION)
+            return null;
+        else
+            return AccessController.doPrivileged(new PrivilegedAction<ClassLoader>() {
+                public ClassLoader run() {
+                    return clazz.getClassLoader();
+                }
+            });
+    }
+
+    /**
+     * Return the class loader which loaded the class passed as argument. Return
+     * the system class loader if appropriate.
+     *
+     * @param clazz
+     * @return
+     */
+    public static ClassLoader getClassLoaderOfClass(final Class<?> clazz) {
+        ClassLoader cl = clazz.getClassLoader();
+        if (cl == null) {
+            return ClassLoader.getSystemClassLoader();
+        } else {
+            return cl;
+        }
+    }
+
+    /**
+     * If running under JDK 1.2 load the specified class using the
+     * <code>Thread</code> <code>contextClassLoader</code> if that fails try
+     * Class.forname. Under JDK 1.1 only Class.forName is used.
+     */
+    public static Class<?> loadClass(String clazz) throws ClassNotFoundException {
+        // Just call Class.forName(clazz) if we are running under JDK 1.1
+        // or if we are instructed to ignore the TCL.
+        if (ignoreTCL) {
+            return Class.forName(clazz);
+        } else {
+            try {
+                return getTCL().loadClass(clazz);
+            } catch (Throwable e) {
+                // we reached here because tcl was null or because of a
+                // security exception, or because clazz could not be loaded...
+                // In any case we now try one more time
+                return Class.forName(clazz);
+            }
+        }
+    }
+
+    /**
+     * diff that made by koupleless, add this loggerContext to loggerContextMap
+     */
+    public static void registerLoggerContext(LoggerContext loggerContext) {
+        loggerContextMap.putIfAbsent(loggerContext, Thread.currentThread().getContextClassLoader());
+    }
+}

--- a/koupleless-adapter-spring-boot-logback-2.7.14/pom.xml
+++ b/koupleless-adapter-spring-boot-logback-2.7.14/pom.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alipay.sofa.koupleless</groupId>
+        <artifactId>koupleless-adapter</artifactId>
+        <version>1.2.2</version>
+    </parent>
+
+    <artifactId>koupleless-adapter-spring-boot-logback-2.7.14</artifactId>
+
+    <properties>
+        <spring.boot.version>2.7.14</spring.boot.version>
+        <java.version>1.8</java.version>
+        <!-- skip deploy parent bundle -->
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.alipay.sofa.koupleless</groupId>
+            <artifactId>koupleless-adapter-logback</artifactId>
+            <version>1.2.2</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <version>1.2.12</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>jul-to-slf4j</artifactId>
+            <version>1.7.36</version>
+            <scope>provided</scope>
+        </dependency>
+
+    </dependencies>
+
+</project>

--- a/koupleless-adapter-spring-boot-logback-2.7.14/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
+++ b/koupleless-adapter-spring-boot-logback-2.7.14/src/main/java/org/springframework/boot/logging/logback/LogbackLoggingSystem.java
@@ -1,0 +1,359 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.logging.logback;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.joran.JoranConfigurator;
+import ch.qos.logback.classic.jul.LevelChangePropagator;
+import ch.qos.logback.classic.turbo.TurboFilter;
+import ch.qos.logback.classic.util.ContextInitializer;
+import ch.qos.logback.core.joran.spi.JoranException;
+import ch.qos.logback.core.spi.FilterReply;
+import ch.qos.logback.core.status.OnConsoleStatusListener;
+import ch.qos.logback.core.status.Status;
+import ch.qos.logback.core.util.Loader;
+import ch.qos.logback.core.util.StatusListenerConfigHelper;
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+import org.slf4j.Marker;
+import org.slf4j.bridge.SLF4JBridgeHandler;
+import org.slf4j.impl.StaticLoggerBinder;
+import org.springframework.boot.logging.LogFile;
+import org.springframework.boot.logging.LogLevel;
+import org.springframework.boot.logging.LoggerConfiguration;
+import org.springframework.boot.logging.LoggingInitializationContext;
+import org.springframework.boot.logging.LoggingSystem;
+import org.springframework.boot.logging.LoggingSystemFactory;
+import org.springframework.boot.logging.LoggingSystemProperties;
+import org.springframework.boot.logging.Slf4JLoggingSystem;
+import org.springframework.core.Ordered;
+import org.springframework.core.SpringProperties;
+import org.springframework.core.annotation.Order;
+import org.springframework.core.env.ConfigurableEnvironment;
+import org.springframework.core.env.Environment;
+import org.springframework.util.Assert;
+import org.springframework.util.ClassUtils;
+import org.springframework.util.ResourceUtils;
+import org.springframework.util.StringUtils;
+
+import java.net.URL;
+import java.security.CodeSource;
+import java.security.ProtectionDomain;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.logging.Handler;
+import java.util.logging.LogManager;
+
+/**
+ * {@link LoggingSystem} for <a href="https://logback.qos.ch">logback</a>.
+ * same from spring-boot v2.5.1 -> v2.7.14
+ *
+ * @author Phillip Webb
+ * @author Dave Syer
+ * @author Andy Wilkinson
+ * @author Ben Hale
+ * @since 1.0.0
+ */
+public class LogbackLoggingSystem extends Slf4JLoggingSystem {
+
+    // Static final field to facilitate code removal by Graal
+    private static final boolean          XML_ENABLED                 = !SpringProperties
+        .getFlag("spring.xml.ignore");
+
+    private static final String           CONFIGURATION_FILE_PROPERTY = "logback.configurationFile";
+
+    private static final LogLevels<Level> LEVELS                      = new LogLevels<>();
+
+    static {
+        LEVELS.map(LogLevel.TRACE, Level.TRACE);
+        LEVELS.map(LogLevel.TRACE, Level.ALL);
+        LEVELS.map(LogLevel.DEBUG, Level.DEBUG);
+        LEVELS.map(LogLevel.INFO, Level.INFO);
+        LEVELS.map(LogLevel.WARN, Level.WARN);
+        LEVELS.map(LogLevel.ERROR, Level.ERROR);
+        LEVELS.map(LogLevel.FATAL, Level.ERROR);
+        LEVELS.map(LogLevel.OFF, Level.OFF);
+    }
+
+    private static final TurboFilter FILTER = new TurboFilter() {
+
+        @Override
+        public FilterReply decide(Marker marker, ch.qos.logback.classic.Logger logger, Level level,
+                                  String format, Object[] params, Throwable t) {
+            return FilterReply.DENY;
+        }
+
+    };
+
+    public LogbackLoggingSystem(ClassLoader classLoader) {
+        super(classLoader);
+    }
+
+    @Override
+    public LoggingSystemProperties getSystemProperties(ConfigurableEnvironment environment) {
+        return new LogbackLoggingSystemProperties(environment);
+    }
+
+    @Override
+    protected String[] getStandardConfigLocations() {
+        return new String[] { "logback-test.groovy", "logback-test.xml", "logback.groovy",
+                              "logback.xml" };
+    }
+
+    @Override
+    public void beforeInitialize() {
+        LoggerContext loggerContext = getLoggerContext();
+        if (isAlreadyInitialized(loggerContext)) {
+            return;
+        }
+        super.beforeInitialize();
+        loggerContext.getTurboFilterList().add(FILTER);
+    }
+
+    @Override
+    public void initialize(LoggingInitializationContext initializationContext,
+                           String configLocation, LogFile logFile) {
+        LoggerContext loggerContext = getLoggerContext();
+        if (isAlreadyInitialized(loggerContext)) {
+            return;
+        }
+        super.initialize(initializationContext, configLocation, logFile);
+        loggerContext.getTurboFilterList().remove(FILTER);
+        markAsInitialized(loggerContext);
+        if (StringUtils.hasText(System.getProperty(CONFIGURATION_FILE_PROPERTY))) {
+            getLogger(LogbackLoggingSystem.class.getName())
+                .warn("Ignoring '" + CONFIGURATION_FILE_PROPERTY
+                      + "' system property. Please use 'logging.config' instead.");
+        }
+    }
+
+    @Override
+    protected void loadDefaults(LoggingInitializationContext initializationContext,
+                                LogFile logFile) {
+        LoggerContext context = getLoggerContext();
+        stopAndReset(context);
+        boolean debug = Boolean.getBoolean("logback.debug");
+        if (debug) {
+            StatusListenerConfigHelper.addOnConsoleListenerInstance(context,
+                new OnConsoleStatusListener());
+        }
+        Environment environment = initializationContext.getEnvironment();
+        // Apply system properties directly in case the same JVM runs multiple apps
+        new LogbackLoggingSystemProperties(environment, context::putProperty).apply(logFile);
+        LogbackConfigurator configurator = debug ? new DebugLogbackConfigurator(context)
+            : new LogbackConfigurator(context);
+        new DefaultLogbackConfiguration(logFile).apply(configurator);
+        context.setPackagingDataEnabled(true);
+    }
+
+    @Override
+    protected void loadConfiguration(LoggingInitializationContext initializationContext,
+                                     String location, LogFile logFile) {
+        super.loadConfiguration(initializationContext, location, logFile);
+        LoggerContext loggerContext = getLoggerContext();
+        stopAndReset(loggerContext);
+        try {
+            configureByResourceUrl(initializationContext, loggerContext,
+                ResourceUtils.getURL(location));
+        } catch (Exception ex) {
+            throw new IllegalStateException("Could not initialize Logback logging from " + location,
+                ex);
+        }
+        List<Status> statuses = loggerContext.getStatusManager().getCopyOfStatusList();
+        StringBuilder errors = new StringBuilder();
+        for (Status status : statuses) {
+            if (status.getLevel() == Status.ERROR) {
+                errors.append((errors.length() > 0) ? String.format("%n") : "");
+                errors.append(status.toString());
+            }
+        }
+        if (errors.length() > 0) {
+            throw new IllegalStateException(
+                String.format("Logback configuration error detected: %n%s", errors));
+        }
+    }
+
+    private void configureByResourceUrl(LoggingInitializationContext initializationContext,
+                                        LoggerContext loggerContext,
+                                        URL url) throws JoranException {
+        if (XML_ENABLED && url.toString().endsWith("xml")) {
+            JoranConfigurator configurator = new SpringBootJoranConfigurator(initializationContext);
+            configurator.setContext(loggerContext);
+            configurator.doConfigure(url);
+        } else {
+            new ContextInitializer(loggerContext).configureByResource(url);
+        }
+    }
+
+    private void stopAndReset(LoggerContext loggerContext) {
+        loggerContext.stop();
+        loggerContext.reset();
+        if (isBridgeHandlerInstalled()) {
+            addLevelChangePropagator(loggerContext);
+        }
+    }
+
+    private boolean isBridgeHandlerInstalled() {
+        if (!isBridgeHandlerAvailable()) {
+            return false;
+        }
+        java.util.logging.Logger rootLogger = LogManager.getLogManager().getLogger("");
+        Handler[] handlers = rootLogger.getHandlers();
+        return handlers.length == 1 && handlers[0] instanceof SLF4JBridgeHandler;
+    }
+
+    private void addLevelChangePropagator(LoggerContext loggerContext) {
+        LevelChangePropagator levelChangePropagator = new LevelChangePropagator();
+        levelChangePropagator.setResetJUL(true);
+        levelChangePropagator.setContext(loggerContext);
+        loggerContext.addListener(levelChangePropagator);
+    }
+
+    @Override
+    public void cleanUp() {
+        LoggerContext context = getLoggerContext();
+        markAsUninitialized(context);
+        super.cleanUp();
+        context.getStatusManager().clear();
+        context.getTurboFilterList().remove(FILTER);
+    }
+
+    @Override
+    protected void reinitialize(LoggingInitializationContext initializationContext) {
+        getLoggerContext().reset();
+        getLoggerContext().getStatusManager().clear();
+        loadConfiguration(initializationContext, getSelfInitializationConfig(), null);
+    }
+
+    @Override
+    public List<LoggerConfiguration> getLoggerConfigurations() {
+        List<LoggerConfiguration> result = new ArrayList<>();
+        for (ch.qos.logback.classic.Logger logger : getLoggerContext().getLoggerList()) {
+            result.add(getLoggerConfiguration(logger));
+        }
+        result.sort(CONFIGURATION_COMPARATOR);
+        return result;
+    }
+
+    @Override
+    public LoggerConfiguration getLoggerConfiguration(String loggerName) {
+        String name = getLoggerName(loggerName);
+        LoggerContext loggerContext = getLoggerContext();
+        return getLoggerConfiguration(loggerContext.exists(name));
+    }
+
+    private String getLoggerName(String name) {
+        if (!StringUtils.hasLength(name) || Logger.ROOT_LOGGER_NAME.equals(name)) {
+            return ROOT_LOGGER_NAME;
+        }
+        return name;
+    }
+
+    private LoggerConfiguration getLoggerConfiguration(ch.qos.logback.classic.Logger logger) {
+        if (logger == null) {
+            return null;
+        }
+        LogLevel level = LEVELS.convertNativeToSystem(logger.getLevel());
+        LogLevel effectiveLevel = LEVELS.convertNativeToSystem(logger.getEffectiveLevel());
+        String name = getLoggerName(logger.getName());
+        return new LoggerConfiguration(name, level, effectiveLevel);
+    }
+
+    @Override
+    public Set<LogLevel> getSupportedLogLevels() {
+        return LEVELS.getSupported();
+    }
+
+    @Override
+    public void setLogLevel(String loggerName, LogLevel level) {
+        ch.qos.logback.classic.Logger logger = getLogger(loggerName);
+        if (logger != null) {
+            logger.setLevel(LEVELS.convertSystemToNative(level));
+        }
+    }
+
+    @Override
+    public Runnable getShutdownHandler() {
+        return () -> getLoggerContext().stop();
+    }
+
+    private ch.qos.logback.classic.Logger getLogger(String name) {
+        LoggerContext factory = getLoggerContext();
+        return factory.getLogger(getLoggerName(name));
+    }
+
+    private LoggerContext getLoggerContext() {
+        ILoggerFactory factory = StaticLoggerBinder.getSingleton().getLoggerFactory();
+        Assert.isInstanceOf(LoggerContext.class, factory,
+            () -> String.format("LoggerFactory is not a Logback LoggerContext but Logback is on "
+                                + "the classpath. Either remove Logback or the competing "
+                                + "implementation (%s loaded from %s). If you are using "
+                                + "WebLogic you will need to add 'org.slf4j' to "
+                                + "prefer-application-packages in WEB-INF/weblogic.xml",
+                factory.getClass(), getLocation(factory)));
+        // diff that made by koupleless, add this loggerContext to loggerContextMap
+        Loader.registerLoggerContext((LoggerContext) factory);
+        return (LoggerContext) factory;
+    }
+
+    private Object getLocation(ILoggerFactory factory) {
+        try {
+            ProtectionDomain protectionDomain = factory.getClass().getProtectionDomain();
+            CodeSource codeSource = protectionDomain.getCodeSource();
+            if (codeSource != null) {
+                return codeSource.getLocation();
+            }
+        } catch (SecurityException ex) {
+            // Unable to determine location
+        }
+        return "unknown location";
+    }
+
+    private boolean isAlreadyInitialized(LoggerContext loggerContext) {
+        return loggerContext.getObject(LoggingSystem.class.getName()) != null;
+    }
+
+    private void markAsInitialized(LoggerContext loggerContext) {
+        loggerContext.putObject(LoggingSystem.class.getName(), new Object());
+    }
+
+    private void markAsUninitialized(LoggerContext loggerContext) {
+        loggerContext.removeObject(LoggingSystem.class.getName());
+    }
+
+    /**
+     * {@link LoggingSystemFactory} that returns {@link LogbackLoggingSystem} if possible.
+     */
+    @Order(Ordered.LOWEST_PRECEDENCE)
+    public static class Factory implements LoggingSystemFactory {
+
+        private static final boolean PRESENT = ClassUtils
+            .isPresent("ch.qos.logback.classic.LoggerContext", Factory.class.getClassLoader());
+
+        @Override
+        public LoggingSystem getLoggingSystem(ClassLoader classLoader) {
+            if (PRESENT) {
+                return new LogbackLoggingSystem(classLoader);
+            }
+            return null;
+        }
+
+    }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
 
 <!--        common feature jar for adapters -->
         <module>features/dubbo3-service-model</module>
+        <module>koupleless-adapter-spring-boot-logback-2.7.14</module>
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION
# Blackgroud
> spring-boot version: 2.7.14

when using `logback` and config custom `Filter<ILoggingEvent>` in biz, runtime framework can not load the custom object.

for example, in biz code:
```java
import ch.qos.logback.classic.spi.ILoggingEvent;
import ch.qos.logback.core.filter.Filter;
public class BizThresholdFilter extends Filter<ILoggingEvent> {
// ...
}
```

in biz logback config:
```xml
<configuration>
    <appender name="APP-APPENDER" class="ch.qos.logback.core.rolling.RollingFileAppender">
        <append>true</append>
        <filter class="com.alipay.sofa.web.biz1.BizThresholdFilter">
            <level>${level}</level>
        </filter>
    </appender>
</configuration>
```

when installing biz1, runtime error:

> Could not create component [filter] of type [com.alipay.sofa.web.biz1.BizThresholdFilter] java.lang.ClassNotFoundException: com.alipay.sofa.web.biz1.BizThresholdFilter
ERROR in ch.qos.logback.core.joran.spi.Interpreter@16:20 - no applicable action for [level], current ElementPath  is [[configuration][appender][filter][level]]

![image](https://github.com/user-attachments/assets/a41f4d91-aba1-4f92-8862-ccd4fc59f37e)

# Modification

add adaptor for logback in spring-boot to use bizclassloader when loading logback filter.

# Result

fix https://github.com/koupleless/koupleless/issues/352

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new logging system for Logback, enhancing logging capabilities within Spring Boot applications.
	- Added a utility class for resource loading and class management, improving logger context handling.

- **Bug Fixes**
	- Corrected typographical errors in property keys for better dependency management.

- **Documentation**
	- Updated project structure and dependencies in the Maven POM file for improved clarity and functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->