### PR TITLE
适配合并部署时，模块的资源目录无法正确的加载

### DIFF
--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/README_zh_CN.md
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/README_zh_CN.md
@@ -1,0 +1,10 @@
+## 适配合并部署时，模块的资源目录无法正确的加载
+https://github.com/sofastack/sofa-ark/issues/1048
+
+## [StaticResourceJars.java](src/main/java/org/springframework/boot/web/servlet/server/StaticResourceJars.java)
+### 遇到问题
+模块所定义的jsp无法被访问，debug查看是没有被加载进去
+### 问题原因
+设置模块的StandardContext的资源目录时，拿到的是tomcat的ClassLoader，通过url属性拿不到正确的模块资源目录
+### 改动点
+重写覆盖掉springboot的org.springframework.boot.web.servlet.server.StaticResourceJars类，将getClass().getClassLoader()改成Thread.currentThread().getContextClassLoader()，获取当前线程的classLoader。再通过classLoader.getParent()拿到BizClassLoader，从而拿到模块对应的资源目录。

--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/conf/adapter-mapping.yaml
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/conf/adapter-mapping.yaml
@@ -1,0 +1,9 @@
+version: 1.2.5
+adapterMappings:
+  - matcher:
+      groupId: org.springframework.boot
+      artifactId: spring-boot
+      versionRange: "[2.1.0,2.7.14]"
+    adapter:
+      artifactId: koupleless-adaptor-module-resource-load-spring-boot-2.7.14
+      groupId: com.alipay.sofa.koupleless

--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/pom.xml
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/pom.xml
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.alipay.sofa.koupleless</groupId>
+        <artifactId>koupleless-adapter</artifactId>
+        <version>${revision}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
+
+    <artifactId>koupleless-adaptor-module-resource-load-spring-boot-2.7.14</artifactId>
+    <version>${revision}</version>
+
+    <properties>
+        <spring.boot.version>2.7.14</spring.boot.version>
+        <sofa.ark.version>2.2.14</sofa.ark.version>
+        <java.version>1.8</java.version>
+        <!-- skip deploy parent bundle -->
+        <maven.deploy.skip>false</maven.deploy.skip>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa</groupId>
+            <artifactId>web-ark-plugin</artifactId>
+            <version>${sofa.ark.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-tomcat</artifactId>
+            <version>${spring.boot.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.alipay.sofa.koupleless</groupId>
+            <artifactId>koupleless-adapter-test-utils</artifactId>
+            <version>0.0.1</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-inline</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-resources-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>copy-test-resources</id>
+                        <phase>process-test-resources</phase>
+                        <goals>
+                            <goal>testResources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${basedir}/target/test-classes/conf/</outputDirectory>
+                            <encoding>UTF-8</encoding>
+                            <resources>
+                                <resource>
+                                    <directory>${basedir}/conf/</directory>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/src/main/java/org/springframework/boot/web/servlet/server/StaticResourceJars.java
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/src/main/java/org/springframework/boot/web/servlet/server/StaticResourceJars.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.springframework.boot.web.servlet.server;
+
+import com.alipay.sofa.ark.web.embed.tomcat.ArkTomcatEmbeddedWebappClassLoader;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.management.ManagementFactory;
+import java.net.*;
+import java.nio.file.InvalidPathException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.jar.JarFile;
+import java.util.stream.Stream;
+
+/**
+ * Logic to extract URLs of static resource jars (those containing
+ * {@code "META-INF/resources"} directories).
+ *
+ * @author Andy Wilkinson
+ * @author Phillip Webb
+ */
+class StaticResourceJars {
+
+    List<URL> getUrls() {
+        // diff for koupleless adaptor in springboot [2.1.0.RELEASE - 2.7.14]
+        // 改造原springboot，兼容koupleless部署无法加载到模块的目录问题
+        ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+        if (classLoader instanceof ArkTomcatEmbeddedWebappClassLoader) {
+            classLoader = classLoader.getParent();
+        }
+        if (classLoader instanceof URLClassLoader) {
+            return getUrlsFrom(((URLClassLoader) classLoader).getURLs());
+        }
+
+        else {
+            return getUrlsFrom(Stream
+                .of(ManagementFactory.getRuntimeMXBean().getClassPath().split(File.pathSeparator))
+                .map(this::toUrl).toArray(URL[]::new));
+        }
+    }
+
+    List<URL> getUrlsFrom(URL... urls) {
+        List<URL> resourceJarUrls = new ArrayList<>();
+        for (URL url : urls) {
+            addUrl(resourceJarUrls, url);
+        }
+        return resourceJarUrls;
+    }
+
+    private URL toUrl(String classPathEntry) {
+        try {
+            return new File(classPathEntry).toURI().toURL();
+        } catch (MalformedURLException ex) {
+            throw new IllegalArgumentException(
+                "URL could not be created from '" + classPathEntry + "'", ex);
+        }
+    }
+
+    private File toFile(URL url) {
+        try {
+            return new File(url.toURI());
+        } catch (URISyntaxException ex) {
+            throw new IllegalStateException("Failed to create File from URL '" + url + "'");
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+
+    private void addUrl(List<URL> urls, URL url) {
+        try {
+            if (!"file".equals(url.getProtocol())) {
+                addUrlConnection(urls, url, url.openConnection());
+            } else {
+                File file = toFile(url);
+                if (file != null) {
+                    addUrlFile(urls, url, file);
+                } else {
+                    addUrlConnection(urls, url, url.openConnection());
+                }
+            }
+        } catch (IOException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    private void addUrlFile(List<URL> urls, URL url, File file) {
+        if ((file.isDirectory() && new File(file, "META-INF/resources").isDirectory())
+            || isResourcesJar(file)) {
+            urls.add(url);
+        }
+    }
+
+    private void addUrlConnection(List<URL> urls, URL url, URLConnection connection) {
+        if (connection instanceof JarURLConnection
+            && isResourcesJar((JarURLConnection) connection)) {
+            urls.add(url);
+        }
+    }
+
+    private boolean isResourcesJar(JarURLConnection connection) {
+        try {
+            return isResourcesJar(connection.getJarFile());
+        } catch (IOException ex) {
+            return false;
+        }
+    }
+
+    private boolean isResourcesJar(File file) {
+        try {
+            return isResourcesJar(new JarFile(file));
+        } catch (IOException | InvalidPathException ex) {
+            return false;
+        }
+    }
+
+    private boolean isResourcesJar(JarFile jar) throws IOException {
+        try {
+            return jar.getName().endsWith(".jar")
+                   && (jar.getJarEntry("META-INF/resources") != null);
+        } finally {
+            jar.close();
+        }
+    }
+
+}

--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/src/test/java/com/alipay/sofa/koupleless/base/build/plugin/MatcherTest.java
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/src/test/java/com/alipay/sofa/koupleless/base/build/plugin/MatcherTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.alipay.sofa.koupleless.base.build.plugin;
+
+import org.apache.maven.model.Dependency;
+import org.eclipse.aether.version.InvalidVersionSpecificationException;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+/**
+ * @author tantuo
+ */
+public class MatcherTest extends MatcherBaseTest {
+
+    public MatcherTest() throws IOException {
+    }
+
+    /**
+     * test for adaptor: koupleless-adaptor-module-resource-load-spring-boot-2.7.14
+     *     matcher:
+     *       groupId: org.springframework.boot
+     *       artifactId: spring-boot
+     *       versionRange: "[2.1.0,2.7.14]"
+     *     adapter:
+     *       artifactId: koupleless-adaptor-module-resource-load-spring-boot-2.7.14
+     *       groupId: com.alipay.sofa.koupleless
+     */
+    @Test
+    public void testMatcher17() throws InvalidVersionSpecificationException {
+        List<Dependency> res = getMatcherAdaptor(
+            mockArtifact("org.springframework.boot", "spring-boot", "2.1.0.RELEASE"));
+        assertEquals(1, res.size());
+        assertEquals(res.get(0).getArtifactId(),
+            "koupleless-adaptor-module-resource-load-spring-boot-2.7.14");
+
+        res = getMatcherAdaptor(mockArtifact("org.springframework.boot", "spring-boot", "2.5.14"));
+        assertEquals(1, res.size());
+        assertEquals(res.get(0).getArtifactId(),
+            "koupleless-adaptor-module-resource-load-spring-boot-2.7.14");
+
+        res = getMatcherAdaptor(mockArtifact("org.springframework.boot", "spring-boot", "2.7.14"));
+        assertEquals(1, res.size());
+        assertEquals(res.get(0).getArtifactId(),
+            "koupleless-adaptor-module-resource-load-spring-boot-2.7.14");
+
+        res = getMatcherAdaptor(mockArtifact("org.springframework.boot", "spring-boot", "2.0.9"));
+        assertEquals(0, res.size());
+
+        res = getMatcherAdaptor(mockArtifact("org.springframework.boot", "spring-boot", "3.0.9"));
+        assertEquals(0, res.size());
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,7 @@
         <module>koupleless-adapter-rocketmq-4.4</module>
         <module>koupleless-adapter-spring-aop-5.3.27</module>
         <module>koupleless-adapter-spring-boot-logback-2.7.14</module>
+        <module>koupleless-adaptor-module-resource-load-spring-boot-2.7.14</module>
 
 <!--        jdk17       -->
         <module>koupleless-adapter-log4j2-spring-starter-3.0</module>
@@ -108,6 +109,7 @@
         <module>koupleless-adapter-configs</module>
         <module>koupleless-adapter-logback-classic-1.4.12</module>
         <module>koupleless-adapter-logback-classic-1.1.6</module>
+
     </modules>
 
     <dependencyManagement>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a new adapter module for Spring Boot resource loading
	- Introduced configuration for handling module resource loading in Spring Boot 2.7.14

- **Documentation**
	- Updated README with details about resource loading and module deployment
	- Added configuration mapping for the new adapter

- **Chores**
	- Created new Maven project structure for the adapter module
	- Added test cases to validate adapter functionality

- **Bug Fixes**
	- Resolved issues with accessing JSP files during module deployment
	- Improved resource directory retrieval for modules

<!-- end of auto-generated comment: release notes by coderabbit.ai -->