### PR TITLE
Fix adaptor module resource load spring boot: rm web-ark-plugin

### DIFF
--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/conf/adapter-mapping.yaml
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/conf/adapter-mapping.yaml
@@ -1,4 +1,4 @@
-version: 1.2.6
+version: 1.2.5
 adapterMappings:
   - matcher:
       groupId: org.springframework.boot

--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/conf/adapter-mapping.yaml
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/conf/adapter-mapping.yaml
@@ -1,4 +1,4 @@
-version: 1.2.5
+version: 1.2.6
 adapterMappings:
   - matcher:
       groupId: org.springframework.boot

--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/pom.xml
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/pom.xml
@@ -29,12 +29,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.alipay.sofa</groupId>
-            <artifactId>web-ark-plugin</artifactId>
-            <version>${sofa.ark.version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-tomcat</artifactId>
             <version>${spring.boot.version}</version>

--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/pom.xml
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/pom.xml
@@ -32,6 +32,7 @@
             <groupId>com.alipay.sofa</groupId>
             <artifactId>web-ark-plugin</artifactId>
             <version>${sofa.ark.version}</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/src/main/java/org/springframework/boot/web/servlet/server/StaticResourceJars.java
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/src/main/java/org/springframework/boot/web/servlet/server/StaticResourceJars.java
@@ -16,8 +16,6 @@
  */
 package org.springframework.boot.web.servlet.server;
 
-import com.alipay.sofa.ark.web.embed.tomcat.ArkTomcatEmbeddedWebappClassLoader;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.management.ManagementFactory;
@@ -39,9 +37,8 @@ class StaticResourceJars {
 
     List<URL> getUrls() {
         // diff for koupleless adaptor in springboot [2.1.0.RELEASE - 2.7.14]
-        // 改造原springboot，兼容koupleless部署无法加载到模块的目录问题
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        if (classLoader instanceof ArkTomcatEmbeddedWebappClassLoader) {
+        if (classLoader.getClass().getName().equals("com.alipay.sofa.ark.web.embed.tomcat.ArkTomcatEmbeddedWebappClassLoader")) {
             classLoader = classLoader.getParent();
         }
         if (classLoader instanceof URLClassLoader) {

--- a/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/src/main/java/org/springframework/boot/web/servlet/server/StaticResourceJars.java
+++ b/koupleless-adaptor-module-resource-load-spring-boot-2.7.14/src/main/java/org/springframework/boot/web/servlet/server/StaticResourceJars.java
@@ -38,7 +38,8 @@ class StaticResourceJars {
     List<URL> getUrls() {
         // diff for koupleless adaptor in springboot [2.1.0.RELEASE - 2.7.14]
         ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
-        if (classLoader.getClass().getName().equals("com.alipay.sofa.ark.web.embed.tomcat.ArkTomcatEmbeddedWebappClassLoader")) {
+        if (classLoader.getClass().getName()
+            .equals("com.alipay.sofa.ark.web.embed.tomcat.ArkTomcatEmbeddedWebappClassLoader")) {
             classLoader = classLoader.getParent();
         }
         if (classLoader instanceof URLClassLoader) {

--- a/pom.xml
+++ b/pom.xml
@@ -9,7 +9,7 @@
     <packaging>pom</packaging>
 
     <properties>
-        <revision>1.2.5</revision>
+        <revision>1.2.6</revision>
         <koupleless.runime.version>1.3.0</koupleless.runime.version>
         <project.encoding>UTF-8</project.encoding>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated adapter mapping configuration version from 1.2.5 to 1.2.6
	- Removed `web-ark-plugin` dependency from project configuration
	- Modified class loader compatibility check in static resource handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->